### PR TITLE
Update Go tools installation to use latest versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,8 +27,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go tools
-RUN go install golang.org/x/tools/cmd/goimports@v0.30.0 \
-    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+RUN go install golang.org/x/tools/cmd/goimports@latest \
+    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 # Create non-root user
 RUN useradd -m -s /bin/bash -u 1000 vscode \


### PR DESCRIPTION
This pull request updates the installation of Go tools in the `.devcontainer/Dockerfile` to always use the latest versions instead of specific pinned versions. This ensures that the development environment stays up-to-date with improvements and bug fixes from these tools.

Development environment updates:

* Changed the `go install` commands to use `@latest` for both `goimports` and `golangci-lint`, rather than specific version numbers. This will automatically install the most recent versions of these tools whenever the container is built.