### PR TITLE
Refactor platform handling to use OS-specific identifiers and update related tests

### DIFF
--- a/examples/client.config.yml
+++ b/examples/client.config.yml
@@ -7,8 +7,8 @@ server_url: "http://sear-daemon:8080"
 # Must match one of the daemon's registration_secrets values.
 registration_secret: "replace-with-a-strong-random-value"
 
-# Platform hint. Use "auto" to let the client detect the environment.
-# Options: auto | baremetal | aws | azure | gcp | custom
+# Platform hint. Use "auto" to let the client detect the OS.
+# Options: auto | linux | mac | windows
 platform: "auto"
 
 # Where the client persists its token and resume position across reboots.

--- a/internal/client/identity/identity.go
+++ b/internal/client/identity/identity.go
@@ -3,18 +3,12 @@
 package identity
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"os"
 	"runtime"
 	"strings"
-	"time"
 )
 
 // PlatformInfo contains the discovered platform identifiers.
@@ -25,19 +19,17 @@ type PlatformInfo struct {
 	Metadata map[string]string
 }
 
-var imdsClient = &http.Client{Timeout: 2 * time.Second}
 
 // Collect gathers platform info. If platformHint is "auto" or empty the
-// platform is auto-detected; otherwise the hint is used directly.
+// platform is auto-detected from the OS; otherwise the hint is used directly.
 func Collect(platformHint string) PlatformInfo {
 	hostname, _ := os.Hostname()
 	if hostname == "" {
 		hostname = "unknown"
 	}
 	meta := map[string]string{
-		"os":      runtime.GOOS,
-		"os_type": runtime.GOOS,
-		"arch":    runtime.GOARCH,
+		"os":   runtime.GOOS,
+		"arch": runtime.GOARCH,
 	}
 	if desc := osDescription(); desc != "" {
 		meta["os_description"] = desc
@@ -48,7 +40,7 @@ func Collect(platformHint string) PlatformInfo {
 		platform = detectPlatform()
 	}
 
-	id := collectID(platform, meta)
+	id := collectID(meta)
 	return PlatformInfo{
 		Platform: platform,
 		ID:       id,
@@ -60,192 +52,21 @@ func Collect(platformHint string) PlatformInfo {
 // ── Platform detection ────────────────────────────────────────────────────────
 
 func detectPlatform() string {
-	// AWS: IMDSv2 token endpoint responds in ~1 ms on EC2.
-	if isAWS() {
-		return "aws"
+	switch runtime.GOOS {
+	case "darwin":
+		return "mac"
+	case "windows":
+		return "windows"
+	default:
+		return "linux"
 	}
-	// Azure: IMDS endpoint is present on all Azure VMs.
-	if isAzure() {
-		return "azure"
-	}
-	// GCP: metadata server returns a recognisable header.
-	if isGCP() {
-		return "gcp"
-	}
-	return "baremetal"
-}
-
-func isAWS() bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
-	defer cancel()
-	// Step 1: get IMDSv2 token.
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPut,
-		"http://169.254.169.254/latest/api/token", nil)
-	req.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "10")
-	resp, err := imdsClient.Do(req)
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
-}
-
-func isAzure() bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
-	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://169.254.169.254/metadata/instance?api-version=2021-02-01", nil)
-	req.Header.Set("Metadata", "true")
-	resp, err := imdsClient.Do(req)
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
-}
-
-func isGCP() bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
-	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://metadata.google.internal/computeMetadata/v1/instance/id", nil)
-	req.Header.Set("Metadata-Flavor", "Google")
-	resp, err := imdsClient.Do(req)
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
 }
 
 // ── ID collection ─────────────────────────────────────────────────────────────
 
-func collectID(platform string, meta map[string]string) string {
-	switch platform {
-	case "aws":
-		if id := awsInstanceID(meta); id != "" {
-			return id
-		}
-	case "azure":
-		if id := azureVMID(meta); id != "" {
-			return id
-		}
-	case "gcp":
-		if id := gcpInstanceID(meta); id != "" {
-			return id
-		}
-	}
-	// Baremetal / generic: try DMI serial, then stable MAC, then random.
+func collectID(meta map[string]string) string {
+	// Use DMI serial, stable MAC, or a random fallback.
 	return baremetalID(meta)
-}
-
-func awsInstanceID(meta map[string]string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	// Get IMDSv2 token first.
-	tokenReq, _ := http.NewRequestWithContext(ctx, http.MethodPut,
-		"http://169.254.169.254/latest/api/token", nil)
-	tokenReq.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "30")
-	tokenResp, err := imdsClient.Do(tokenReq)
-	if err != nil {
-		return ""
-	}
-	tokenBytes, _ := io.ReadAll(tokenResp.Body)
-	tokenResp.Body.Close()
-	token := strings.TrimSpace(string(tokenBytes))
-
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://169.254.169.254/latest/meta-data/instance-id", nil)
-	req.Header.Set("X-aws-ec2-metadata-token", token)
-	resp, err := imdsClient.Do(req)
-	if err != nil {
-		return ""
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
-	id := strings.TrimSpace(string(b))
-	if id != "" {
-		meta["aws_instance_id"] = id
-		// Also grab region.
-		if region := awsMeta(token, "placement/region"); region != "" {
-			meta["aws_region"] = region
-		}
-	}
-	return "aws-" + id
-}
-
-func awsMeta(token, path string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://169.254.169.254/latest/meta-data/"+path, nil)
-	req.Header.Set("X-aws-ec2-metadata-token", token)
-	resp, err := imdsClient.Do(req)
-	if err != nil {
-		return ""
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
-	return strings.TrimSpace(string(b))
-}
-
-func azureVMID(meta map[string]string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
-		"http://169.254.169.254/metadata/instance?api-version=2021-02-01", nil)
-	req.Header.Set("Metadata", "true")
-	resp, err := imdsClient.Do(req)
-	if err != nil {
-		return ""
-	}
-	defer resp.Body.Close()
-	var payload struct {
-		Compute struct {
-			VMID           string `json:"vmId"`
-			ResourceGroup  string `json:"resourceGroupName"`
-			Location       string `json:"location"`
-		} `json:"compute"`
-	}
-	if json.NewDecoder(resp.Body).Decode(&payload) != nil {
-		return ""
-	}
-	if payload.Compute.VMID != "" {
-		meta["azure_vm_id"] = payload.Compute.VMID
-		meta["azure_resource_group"] = payload.Compute.ResourceGroup
-		meta["azure_location"] = payload.Compute.Location
-	}
-	return "azure-" + payload.Compute.VMID
-}
-
-func gcpInstanceID(meta map[string]string) string {
-	id := gcpMeta("instance/id")
-	if id == "" {
-		return ""
-	}
-	meta["gcp_instance_id"] = id
-	if zone := gcpMeta("instance/zone"); zone != "" {
-		// zone is "projects/PROJECT/zones/ZONE" — extract last segment.
-		parts := strings.Split(zone, "/")
-		meta["gcp_zone"] = parts[len(parts)-1]
-	}
-	return "gcp-" + id
-}
-
-func gcpMeta(path string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
-		fmt.Sprintf("http://metadata.google.internal/computeMetadata/v1/%s", path), nil)
-	req.Header.Set("Metadata-Flavor", "Google")
-	resp, err := imdsClient.Do(req)
-	if err != nil {
-		return ""
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
-	return strings.TrimSpace(string(b))
 }
 
 func baremetalID(meta map[string]string) string {

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -67,8 +67,8 @@ type ClientConfig struct {
 	// RegistrationSecret must match one of the daemon's registration_secrets values.
 	RegistrationSecret string `yaml:"registration_secret"`
 
-	// Platform hint: baremetal | aws | azure | gcp | custom | auto (default).
-	// When "auto", the client detects the platform from the environment.
+	// Platform hint: linux | mac | windows | auto (default).
+	// When "auto", the client detects the platform from the OS.
 	Platform string `yaml:"platform"`
 
 	// StateFile is where the client persists its token and resume position

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -119,15 +119,13 @@ func ResolveEnvSecrets(env map[string]string, secrets map[string]string) map[str
 
 // ── Client / registration types ───────────────────────────────────────────────
 
-// PlatformType identifies the hardware / cloud platform.
+// PlatformType identifies the operating system platform.
 type PlatformType string
 
 const (
-	PlatformBaremetal PlatformType = "baremetal"
-	PlatformAzure     PlatformType = "azure"
-	PlatformAWS       PlatformType = "aws"
-	PlatformGCP       PlatformType = "gcp"
-	PlatformCustom    PlatformType = "custom"
+	PlatformLinux   PlatformType = "linux"
+	PlatformMac     PlatformType = "mac"
+	PlatformWindows PlatformType = "windows"
 )
 
 // RegistrationRequest is sent by a client to POST /api/v1/register.
@@ -159,12 +157,11 @@ const (
 
 // Client holds server-side information about a registered client machine.
 type Client struct {
-	ID           string            `json:"id"`
-	Hostname     string            `json:"hostname"`
-	Platform     PlatformType      `json:"platform"`
-	OS           string            `json:"os,omitempty"`
-	OSType       string            `json:"os_type,omitempty"`
-	OSDescription string           `json:"os_description,omitempty"`
+	ID            string            `json:"id"`
+	Hostname      string            `json:"hostname"`
+	Platform      PlatformType      `json:"platform"`
+	OS            string            `json:"os,omitempty"`
+	OSDescription string            `json:"os_description,omitempty"`
 	PlatformID   string            `json:"platform_id"`
 	IPAddress    string            `json:"ip_address,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`

--- a/internal/daemon/handlers/auth.go
+++ b/internal/daemon/handlers/auth.go
@@ -149,10 +149,6 @@ func (e *Env) HandleRegister(w http.ResponseWriter, r *http.Request) {
 	client.Hostname = req.Hostname
 	client.Platform = req.Platform
 	client.OS = req.Metadata["os"]
-	client.OSType = req.Metadata["os_type"]
-	if client.OSType == "" {
-		client.OSType = client.OS
-	}
 	client.OSDescription = req.Metadata["os_description"]
 	client.PlatformID = req.PlatformID
 	client.IPAddress = requestIP(r)

--- a/internal/daemon/handlers/handlers_test.go
+++ b/internal/daemon/handlers/handlers_test.go
@@ -89,7 +89,7 @@ func decode[T any](t *testing.T, rr *httptest.ResponseRecorder) T {
 func registerClient(t *testing.T, env *handlers.Env, platformID, hostname string) (string, string) {
 	t.Helper()
 	rr := postJSON(t, env.HandleRegister, "/api/v1/register", common.RegistrationRequest{
-		Platform:           common.PlatformBaremetal,
+		Platform:           common.PlatformLinux,
 		PlatformID:         platformID,
 		Hostname:           hostname,
 		RegistrationSecret: "reg-secret-1",
@@ -106,7 +106,7 @@ func registerClient(t *testing.T, env *handlers.Env, platformID, hostname string
 func TestHandleRegister_Success(t *testing.T) {
 	env := newTestEnv(t)
 	rr := postJSON(t, env.HandleRegister, "/api/v1/register", common.RegistrationRequest{
-		Platform:           common.PlatformBaremetal,
+		Platform:           common.PlatformLinux,
 		PlatformID:         "SN-001",
 		Hostname:           "edge-01",
 		RegistrationSecret: "reg-secret-1",
@@ -126,7 +126,7 @@ func TestHandleRegister_Success(t *testing.T) {
 func TestHandleRegister_InvalidSecret(t *testing.T) {
 	env := newTestEnv(t)
 	rr := postJSON(t, env.HandleRegister, "/api/v1/register", common.RegistrationRequest{
-		Platform:           common.PlatformBaremetal,
+		Platform:           common.PlatformLinux,
 		PlatformID:         "SN-002",
 		Hostname:           "edge-02",
 		RegistrationSecret: "wrong-secret",
@@ -149,7 +149,7 @@ func TestHandleRegister_MissingFields(t *testing.T) {
 func TestHandleRegister_Idempotent(t *testing.T) {
 	env := newTestEnv(t)
 	req := common.RegistrationRequest{
-		Platform:           common.PlatformBaremetal,
+		Platform:           common.PlatformLinux,
 		PlatformID:         "SN-003",
 		Hostname:           "edge-03",
 		RegistrationSecret: "reg-secret-1",
@@ -169,7 +169,7 @@ func TestHandleRegister_CapturesClientIP(t *testing.T) {
 	env := newTestEnv(t)
 
 	body, err := json.Marshal(common.RegistrationRequest{
-		Platform:           common.PlatformBaremetal,
+		Platform:           common.PlatformLinux,
 		PlatformID:         "SN-004",
 		Hostname:           "edge-04",
 		RegistrationSecret: "reg-secret-1",
@@ -202,13 +202,12 @@ func TestHandleRegister_CapturesClientOS(t *testing.T) {
 	env := newTestEnv(t)
 
 	body, err := json.Marshal(common.RegistrationRequest{
-		Platform:           common.PlatformBaremetal,
+		Platform:           common.PlatformLinux,
 		PlatformID:         "SN-005",
 		Hostname:           "edge-05",
 		RegistrationSecret: "reg-secret-1",
 		Metadata: map[string]string{
 			"os":             "linux",
-			"os_type":        "linux",
 			"os_description": "Debian GNU/Linux 12 (bookworm)",
 		},
 	})
@@ -232,9 +231,6 @@ func TestHandleRegister_CapturesClientOS(t *testing.T) {
 	}
 	if client.OS != "linux" {
 		t.Errorf("os = %q; want %q", client.OS, "linux")
-	}
-	if client.OSType != "linux" {
-		t.Errorf("os_type = %q; want %q", client.OSType, "linux")
 	}
 	if client.OSDescription != "Debian GNU/Linux 12 (bookworm)" {
 		t.Errorf("os_description = %q; want %q", client.OSDescription, "Debian GNU/Linux 12 (bookworm)")

--- a/internal/daemon/store/store_test.go
+++ b/internal/daemon/store/store_test.go
@@ -27,7 +27,7 @@ func TestClientCRUD(t *testing.T) {
 	c := &common.Client{
 		ID:           "client-1",
 		Hostname:     "edge-01",
-		Platform:     common.PlatformBaremetal,
+		Platform:     common.PlatformLinux,
 		PlatformID:   "SN-12345",
 		Status:       common.ClientStatusRegistered,
 		RegisteredAt: time.Now(),


### PR DESCRIPTION
This pull request refactors the platform detection logic throughout the codebase to focus on the operating system (OS) rather than hardware or cloud environments. It removes all cloud-specific platform detection (AWS, Azure, GCP) and replaces it with OS-based detection (Linux, Mac, Windows). The change simplifies configuration, client registration, and platform identification, and updates related tests and comments accordingly.

Platform detection and configuration changes:

* Updated `ClientConfig` and `client.config.yml` to use OS-based platform hints (`linux`, `mac`, `windows`, `auto`) instead of previous cloud/hardware options. Comments and documentation were revised to clarify the new behavior. [[1]](diffhunk://#diff-61a0ca83e0ff097893db0d8b91dc2be1b0a1cf1ceb19a21175b421a217745e14L10-R11) [[2]](diffhunk://#diff-daf3824d8525da7bb3ee1fef200c959c0a7fd7e7f64460fe9e3e9946cfabe672L70-R71)
* Refactored platform detection in `identity.go` to use `runtime.GOOS` for determining platform, removing all cloud metadata queries and related helper functions. The platform ID collection logic was simplified to only use baremetal methods. [[1]](diffhunk://#diff-e91a4ddeb2506dd3f46db135b2762bccb92390201a1ac5d986f66ed48a6d659fL28-L39) [[2]](diffhunk://#diff-e91a4ddeb2506dd3f46db135b2762bccb92390201a1ac5d986f66ed48a6d659fL51-R43) [[3]](diffhunk://#diff-e91a4ddeb2506dd3f46db135b2762bccb92390201a1ac5d986f66ed48a6d659fL63-L250)

Type and struct updates:

* Changed `PlatformType` definition and constants to represent OS platforms instead of cloud/hardware types. Removed the now-redundant `OSType` field from the `Client` struct and related code. [[1]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL122-R128) [[2]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL166) [[3]](diffhunk://#diff-6862296056e5eccd6d9b4ae743818eafbe3696534cf889fc2d0d442777dbd928L152-L155)

Test updates:

* Updated all tests in `handlers_test.go` and `store_test.go` to use the new platform constants (`PlatformLinux`), and removed references to the old platform types and `os_type` metadata. [[1]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L92-R92) [[2]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L109-R109) [[3]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L129-R129) [[4]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L152-R152) [[5]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L172-R172) [[6]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L205-L211) [[7]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L236-L238) [[8]](diffhunk://#diff-535518cea2bd9020fb21a4829bb3078f04ddecbc448106321a2c927ef3e6a7a8L30-R30)