### PR TITLE
Implement WebSocket ping/pong mechanism to maintain connection stability

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -133,7 +133,10 @@ func (c *Client) connect(ctx context.Context) error {
 
 	log.Printf("WebSocket connected")
 
-	ws.SetPingHandler(func(string) error {
+	ws.SetPingHandler(func(appData string) error {
+		// Reset the read deadline so the server's periodic pings keep the
+		// connection alive on our side too.
+		_ = ws.SetReadDeadline(time.Now().Add(90 * time.Second))
 		return ws.WriteControl(websocket.PongMessage, nil, time.Now().Add(5*time.Second))
 	})
 

--- a/internal/daemon/handlers/connect.go
+++ b/internal/daemon/handlers/connect.go
@@ -68,6 +68,25 @@ func (e *Env) HandleWS(w http.ResponseWriter, r *http.Request) {
 		return ws.SetReadDeadline(time.Now().Add(90 * time.Second))
 	})
 
+	// Send pings every 30 s so the client resets its read deadline and replies
+	// with a pong that resets ours.  WriteControl is safe to call concurrently.
+	pingDone := make(chan struct{})
+	defer close(pingDone)
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := ws.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second)); err != nil {
+					return
+				}
+			case <-pingDone:
+				return
+			}
+		}
+	}()
+
 	for {
 		_, data, err := ws.ReadMessage()
 		if err != nil {


### PR DESCRIPTION
This pull request improves the WebSocket connection reliability between the client and server by ensuring that both sides regularly reset their read deadlines, preventing connection timeouts. The main changes are focused on handling WebSocket ping/pong messages more robustly.

WebSocket connection reliability improvements:

* Modified the client's `SetPingHandler` to reset the read deadline upon receiving a ping, ensuring the connection stays alive when the server sends periodic pings. (`internal/client/client.go`)
* Added a goroutine on the server side to send ping messages every 30 seconds, prompting the client to reply with a pong and reset its own read deadline, further improving connection stability. (`internal/daemon/handlers/connect.go`)