### PR TITLE
Refactor API routes to include versioning and update documentation for consistency 

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -125,6 +125,20 @@ sear/
 - Logs are persisted per deployment under logsDir and not in state.json.
 - Keep job and step order deterministic in playbook processing.
 
+## Route conventions
+
+Keep route structure consistent:
+
+- API endpoints are versioned under `/api/v1`.
+  - Public/client control examples: `/api/v1/register`, `/api/v1/ws`
+  - Root management examples: `/api/v1/status`, `/api/v1/secrets`, `/api/v1/playbooks`, `/api/v1/clients`, `/api/v1/deployments`
+- Browser UI pages are under `/ui`.
+  - `/ui`, `/ui/secrets`, `/ui/playbooks`, `/ui/deployments`
+- When adding a new resource:
+  - expose API under `/api/v1/<resource>`
+  - expose UI under `/ui/<resource>` when needed
+  - update `docs/api-endpoints.md`, `README.md`, and tests in the same change
+
 ## CI and release
 
 CI workflow:

--- a/README.md
+++ b/README.md
@@ -72,8 +72,13 @@ If `root_password` or `registration_secrets` are missing, the daemon generates t
 
 ### 5) Open status dashboard
 
-- URL: `http://localhost:8080/status/ui`
-- Auth: HTTP Basic
+- URL: `http://localhost:8080/ui`
+- UI pages:
+	- `/ui` (clients/status)
+	- `/ui/secrets`
+	- `/ui/playbooks`
+	- `/ui/deployments`
+- Auth: sign in from the UI (HTTP Basic credentials used for API calls)
 - Username: `root`
 - Password: value from `root_password` in secrets file (or generated password printed at startup)
 
@@ -134,3 +139,9 @@ Example playbook: `examples/playbook.yml`
 
 - API endpoints: [docs/api-endpoints.md](docs/api-endpoints.md)
 - Contributor and development guide: [CONTRIBUTING.MD](CONTRIBUTING.MD)
+
+## API route conventions
+
+- Public/client control endpoints are under `/api/v1` (for example `/api/v1/register`, `/api/v1/ws`).
+- Root management APIs are also under `/api/v1` (for example `/api/v1/status`, `/api/v1/secrets`, `/api/v1/playbooks`, `/api/v1/clients`, `/api/v1/deployments`).
+- Browser pages are under `/ui`.

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -25,74 +25,94 @@ This document describes the HTTP and WebSocket endpoints exposed by sear-daemon.
 
 ## Root endpoints
 
-All root endpoints require HTTP Basic auth.
+Root management APIs require HTTP Basic auth.
 
-### Status
+### UI pages
 
-- `GET /status`
+UI pages are served under `/ui`:
+
+- `GET /ui`
+  - Clients/status dashboard UI
+
+- `GET /ui/secrets`
+  - Secrets management UI
+
+- `GET /ui/playbooks`
+  - Playbooks management UI
+
+- `GET /ui/deployments`
+  - Deployments and logs UI
+
+The UI signs in and then calls the root APIs below using HTTP Basic credentials.
+
+### Status API
+
+- `GET /api/v1/status`
   - JSON summary of clients and deployments
-
-- `GET /status/ui`
-  - Live HTML dashboard
 
 ### Playbooks
 
-- `GET /playbooks`
+- `GET /api/v1/playbooks`
   - List all playbooks
 
-- `POST /playbooks`
+- `POST /api/v1/playbooks`
   - Create playbook
+  - Accepts JSON payload with either:
+    - `playbook` (JSON object), or
+    - `playbook_yaml` (string)
 
-- `GET /playbooks/{id}`
+- `GET /api/v1/playbooks/{id}`
   - Get a playbook
+  - Includes `playbook_yaml` in response for editor-friendly roundtrips
 
-- `PUT /playbooks/{id}`
+- `PUT /api/v1/playbooks/{id}`
   - Update playbook
+  - Accepts `playbook` or `playbook_yaml` (same as create)
 
-- `DELETE /playbooks/{id}`
+- `DELETE /api/v1/playbooks/{id}`
   - Delete playbook
 
-- `POST /playbooks/{id}/assign`
+- `POST /api/v1/playbooks/{id}/assign`
   - Assign playbook to a client
   - If client is connected, deployment is pushed immediately
 
 ### Clients
 
-- `GET /clients`
+- `GET /api/v1/clients`
   - List clients
 
-- `GET /clients/{id}`
+- `GET /api/v1/clients/{id}`
   - Get client
 
-- `PUT /clients/{id}`
+- `PUT /api/v1/clients/{id}`
   - Update client fields such as `playbook_id` or `status`
 
-- `DELETE /clients/{id}`
+- `DELETE /api/v1/clients/{id}`
   - Delete client
 
 ### Deployments
 
-- `GET /deployments`
+- `GET /api/v1/deployments`
   - List deployments
 
-- `GET /deployments/{id}`
+- `GET /api/v1/deployments/{id}`
   - Get deployment details
 
-- `GET /deployments/{id}/logs`
+- `GET /api/v1/deployments/{id}/logs`
   - Get deployment log entries
 
 ### Secrets
 
-- `GET /secrets`
+- `GET /api/v1/secrets`
   - List secret names
 
-- `GET /secrets/{name}`
+- `GET /api/v1/secrets/{name}`
   - Get secret value
 
-- `PUT /secrets/{name}`
+- `PUT /api/v1/secrets/{name}`
   - Set or update secret value
 
-- `DELETE /secrets/{name}`
+- `DELETE /api/v1/secrets/{name}`
   - Delete secret
 
 ## Artifacts endpoints

--- a/internal/daemon/handlers/admin.go
+++ b/internal/daemon/handlers/admin.go
@@ -18,25 +18,24 @@ import (
 
 // StatusResponse is returned by GET /api/v1/status (JSON) and used by the /ui status dashboard.
 type StatusResponse struct {
-	Clients      []*common.Client          `json:"clients"`
-	Deployments  []*common.DeploymentState `json:"deployments"`
-	TotalClients int                       `json:"total_clients,omitempty"`
+	Clients     []*common.Client          `json:"clients"`
+	Deployments []*common.DeploymentState `json:"deployments"`
 }
 
-// ── /playbooks ────────────────────────────────────────────────────────────────────
+// ── /api/v1/playbooks ─────────────────────────────────────────────────────────────
 
 // HandleRootPlaybooks dispatches CRUD on playbooks.
 //
-//	GET    /playbooks              – list all
-//	POST   /playbooks              – create
-//	GET    /playbooks/{id}         – get one
-//	PUT    /playbooks/{id}         – update
-//	DELETE /playbooks/{id}         – delete
-//	POST   /playbooks/{id}/assign  – assign to a client (pushes immediately
-//	                                 if client is connected via WebSocket)
+//	GET    /api/v1/playbooks              – list all
+//	POST   /api/v1/playbooks              – create
+//	GET    /api/v1/playbooks/{id}         – get one
+//	PUT    /api/v1/playbooks/{id}         – update
+//	DELETE /api/v1/playbooks/{id}         – delete
+//	POST   /api/v1/playbooks/{id}/assign  – assign to a client (pushes immediately
+//	                                         if client is connected via WebSocket)
 func (e *Env) HandleRootPlaybooks(w http.ResponseWriter, r *http.Request) {
 	// Strip prefix to isolate the path tail.
-	tail := strings.TrimPrefix(r.URL.Path, "/playbooks")
+	tail := strings.TrimPrefix(r.URL.Path, "/api/v1/playbooks")
 	tail = strings.TrimPrefix(tail, "/")
 	parts := strings.SplitN(tail, "/", 2)
 	id := parts[0]
@@ -214,16 +213,16 @@ func (e *Env) assignPlaybook(w http.ResponseWriter, r *http.Request, playbookID 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "assigned"})
 }
 
-// ── /clients ──────────────────────────────────────────────────────────────────────
+// ── /api/v1/clients ───────────────────────────────────────────────────────────────
 
 // HandleRootClients dispatches CRUD on clients.
 //
-//	GET    /clients          – list all
-//	GET    /clients/{id}     – get one
-//	PUT    /clients/{id}     – update (e.g. assign playbook, set status)
-//	DELETE /clients/{id}     – delete
+//	GET    /api/v1/clients          – list all
+//	GET    /api/v1/clients/{id}     – get one
+//	PUT    /api/v1/clients/{id}     – update (e.g. assign playbook, set status)
+//	DELETE /api/v1/clients/{id}     – delete
 func (e *Env) HandleRootClients(w http.ResponseWriter, r *http.Request) {
-	tail := strings.TrimPrefix(r.URL.Path, "/clients")
+	tail := strings.TrimPrefix(r.URL.Path, "/api/v1/clients")
 	tail = strings.TrimPrefix(tail, "/")
 	id := tail
 
@@ -286,19 +285,19 @@ func (e *Env) HandleRootClients(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// ── /deployments ──────────────────────────────────────────────────────────────────
+// ── /api/v1/deployments ───────────────────────────────────────────────────────────
 
 // HandleRootDeployments lists deployments and exposes per-deployment logs.
 //
-//	GET /deployments              – list all
-//	GET /deployments/{id}         – get one
-//	GET /deployments/{id}/logs    – get logs for deployment
+//	GET /api/v1/deployments              – list all
+//	GET /api/v1/deployments/{id}         – get one
+//	GET /api/v1/deployments/{id}/logs    – get logs for deployment
 func (e *Env) HandleRootDeployments(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	path := strings.TrimPrefix(r.URL.Path, "/deployments")
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/deployments")
 	path = strings.TrimPrefix(path, "/")
 	parts := strings.SplitN(path, "/", 2)
 	id := parts[0]

--- a/internal/daemon/handlers/connect.go
+++ b/internal/daemon/handlers/connect.go
@@ -520,7 +520,7 @@ async function removeClient(id, hostname) {
   const creds = sessionStorage.getItem('sear_creds');
   const headers = {'Content-Type':'application/json'};
   if (creds) headers['Authorization'] = 'Basic ' + creds;
-  const r = await fetch('/clients/' + encodeURIComponent(id), {method:'DELETE', headers});
+	const r = await fetch('/api/v1/clients/' + encodeURIComponent(id), {method:'DELETE', headers});
   if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
   if (!r.ok) { alert('Failed to remove client: ' + r.status); return; }
   load();

--- a/internal/daemon/handlers/deployments_ui.go
+++ b/internal/daemon/handlers/deployments_ui.go
@@ -139,7 +139,7 @@ async function doLogin(){
   var p=document.getElementById('lp').value;
   if(!p){document.getElementById('login-error').textContent='Password required';return;}
   var creds=btoa(u+':'+p);
-  var r=await fetch('/deployments',{headers:{Authorization:'Basic '+creds}});
+  var r=await fetch('/api/v1/deployments',{headers:{Authorization:'Basic '+creds}});
   if(r.status===401){document.getElementById('login-error').textContent='Invalid password';return;}
   sessionStorage.setItem('sear_creds',creds);
   hideLogin();
@@ -210,7 +210,7 @@ async function openLogs(id){
   document.getElementById('logs-title').textContent='Logs: '+id;
   p.style.display='block';
   root.innerHTML='<div class="empty">Loading logs...</div>';
-  var r=await fetch('/deployments/'+encodeURIComponent(id)+'/logs',{headers:headersAuth()});
+  var r=await fetch('/api/v1/deployments/'+encodeURIComponent(id)+'/logs',{headers:headersAuth()});
   if(r.status===401){showLogin('Session expired - sign in again');return;}
   if(!r.ok){root.innerHTML='<div class="empty">Failed to load logs.</div>';return;}
   var logs=await r.json()||[];
@@ -247,7 +247,7 @@ function closeLogs(){document.getElementById('logs-panel').style.display='none';
 async function load(){
   var auth=authHeader();
   if(!auth){showLogin('');return;}
-  var r=await fetch('/deployments',{headers:headersAuth()});
+  var r=await fetch('/api/v1/deployments',{headers:headersAuth()});
   if(r.status===401){showLogin('');return;}
   if(!r.ok){document.getElementById('root').innerHTML='<div class="empty">Failed to load deployments.</div>';return;}
   deployments=await r.json()||[];

--- a/internal/daemon/handlers/handlers_test.go
+++ b/internal/daemon/handlers/handlers_test.go
@@ -343,7 +343,7 @@ func TestHandleRootPlaybooks_CRUD(t *testing.T) {
 		},
 	}
 	b, _ := json.Marshal(body)
-	req := httptest.NewRequest(http.MethodPost, "/playbooks", bytes.NewReader(b))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/playbooks", bytes.NewReader(b))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	env.HandleRootPlaybooks(rr, req)
@@ -357,7 +357,7 @@ func TestHandleRootPlaybooks_CRUD(t *testing.T) {
 	}
 
 	// List.
-	req2 := httptest.NewRequest(http.MethodGet, "/playbooks", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/playbooks", nil)
 	rr2 := httptest.NewRecorder()
 	env.HandleRootPlaybooks(rr2, req2)
 	var list []*store.PlaybookRecord
@@ -367,8 +367,8 @@ func TestHandleRootPlaybooks_CRUD(t *testing.T) {
 	}
 
 	// Get by ID.
-	req3 := httptest.NewRequest(http.MethodGet, "/playbooks/"+created.ID, nil)
-	req3.URL.Path = "/playbooks/" + created.ID
+	req3 := httptest.NewRequest(http.MethodGet, "/api/v1/playbooks/"+created.ID, nil)
+	req3.URL.Path = "/api/v1/playbooks/" + created.ID
 	rr3 := httptest.NewRecorder()
 	env.HandleRootPlaybooks(rr3, req3)
 	if rr3.Code != http.StatusOK {
@@ -376,8 +376,8 @@ func TestHandleRootPlaybooks_CRUD(t *testing.T) {
 	}
 
 	// Delete.
-	req4 := httptest.NewRequest(http.MethodDelete, "/playbooks/"+created.ID, nil)
-	req4.URL.Path = "/playbooks/" + created.ID
+	req4 := httptest.NewRequest(http.MethodDelete, "/api/v1/playbooks/"+created.ID, nil)
+	req4.URL.Path = "/api/v1/playbooks/" + created.ID
 	rr4 := httptest.NewRecorder()
 	env.HandleRootPlaybooks(rr4, req4)
 	if rr4.Code != http.StatusOK {
@@ -451,8 +451,8 @@ func TestCrossClientDeploymentForbidden(t *testing.T) {
 	_ = env.Store.SaveDeployment(dep)
 
 	// Root reading logs for someone else's deployment should work.
-	req := httptest.NewRequest(http.MethodGet, "/deployments/dep-owned/logs", nil)
-	req.URL.Path = "/deployments/dep-owned/logs"
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/deployments/dep-owned/logs", nil)
+	req.URL.Path = "/api/v1/deployments/dep-owned/logs"
 	rr := httptest.NewRecorder()
 	env.HandleRootDeployments(rr, req)
 	if rr.Code != http.StatusOK {

--- a/internal/daemon/handlers/playbooks_ui.go
+++ b/internal/daemon/handlers/playbooks_ui.go
@@ -145,7 +145,7 @@ async function doLogin(){
   var p=document.getElementById('lp').value;
   if(!p){document.getElementById('login-error').textContent='Password required';return;}
   var creds=btoa(u+':'+p);
-  var r=await fetch('/playbooks',{headers:{Authorization:'Basic '+creds}});
+  var r=await fetch('/api/v1/playbooks',{headers:{Authorization:'Basic '+creds}});
   if(r.status===401){document.getElementById('login-error').textContent='Invalid password';return;}
   sessionStorage.setItem('sear_creds',creds);
   hideLogin();
@@ -190,7 +190,7 @@ async function openEdit(i){
   document.getElementById('pb-modal-err').textContent='';
   document.getElementById('pb-modal-bg').classList.add('show');
 
-  var r=await fetch('/playbooks/'+encodeURIComponent(pb.id),{headers:headersAuth()});
+  var r=await fetch('/api/v1/playbooks/'+encodeURIComponent(pb.id),{headers:headersAuth()});
   if(r.status===401){closePBModal();showLogin('Session expired - sign in again');return;}
   if(!r.ok){document.getElementById('pb-modal-err').textContent='Failed to load playbook details';return;}
   var full=await r.json();
@@ -206,7 +206,7 @@ async function savePlaybook(){
   if(!name){errEl.textContent='Name is required';return;}
   if(!raw.trim()){errEl.textContent='Playbook YAML is required';return;}
   var payload={name:name,description:desc,playbook_yaml:raw};
-  var url=editingID?('/playbooks/'+encodeURIComponent(editingID)):'/playbooks';
+  var url=editingID?('/api/v1/playbooks/'+encodeURIComponent(editingID)):'/api/v1/playbooks';
   var method=editingID?'PUT':'POST';
   var r=await fetch(url,{method:method,headers:headersJSON(),body:JSON.stringify(payload)});
   if(r.status===401){closePBModal();showLogin('Session expired - sign in again');return;}
@@ -223,7 +223,7 @@ async function savePlaybook(){
 async function removePlaybook(i){
   var pb=playbooks[i];
   if(!confirm('Delete playbook "'+(pb.name||pb.id)+'"?'))return;
-  var r=await fetch('/playbooks/'+encodeURIComponent(pb.id),{method:'DELETE',headers:headersAuth()});
+  var r=await fetch('/api/v1/playbooks/'+encodeURIComponent(pb.id),{method:'DELETE',headers:headersAuth()});
   if(r.status===401){showLogin('Session expired - sign in again');return;}
   if(!r.ok){alert('Delete failed: '+r.status);return;}
   load();
@@ -245,7 +245,7 @@ async function confirmAssign(){
   var errEl=document.getElementById('assign-modal-err');
   var clientID=document.getElementById('assign-client').value;
   if(!clientID){errEl.textContent='Select a client';return;}
-  var r=await fetch('/playbooks/'+encodeURIComponent(assigningID)+'/assign',{method:'POST',headers:headersJSON(),body:JSON.stringify({client_id:clientID})});
+  var r=await fetch('/api/v1/playbooks/'+encodeURIComponent(assigningID)+'/assign',{method:'POST',headers:headersJSON(),body:JSON.stringify({client_id:clientID})});
   if(r.status===401){closeAssignModal();showLogin('Session expired - sign in again');return;}
   if(!r.ok){
     var msg='Assign failed ('+r.status+')';
@@ -285,10 +285,10 @@ function render(){
 async function load(){
   var auth=authHeader();
   if(!auth){showLogin('');return;}
-  var p=await fetch('/playbooks',{headers:headersAuth()});
+  var p=await fetch('/api/v1/playbooks',{headers:headersAuth()});
   if(p.status===401){showLogin('');return;}
   if(!p.ok){document.getElementById('root').innerHTML='<div class="empty">Failed to load playbooks.</div>';return;}
-  var c=await fetch('/clients',{headers:headersAuth()});
+  var c=await fetch('/api/v1/clients',{headers:headersAuth()});
   clients=c.ok?await c.json():[];
   playbooks=await p.json()||[];
   render();

--- a/internal/daemon/handlers/secrets.go
+++ b/internal/daemon/handlers/secrets.go
@@ -10,21 +10,23 @@ import (
 // HandleSecrets manages the server-side secrets store.
 //
 // Primary API (mounted by NewServer):
+//
 //	GET    /api/v1/secrets          – list secret names (values are never exposed in list)
 //	GET    /api/v1/secrets/{name}   – get a specific secret value
 //	PUT    /api/v1/secrets/{name}   – set or update a secret value
 //	DELETE /api/v1/secrets/{name}   – delete a secret
 //
 // Legacy paths (still accepted for backward compatibility):
+//
 //	GET    /secrets                 – list secret names (values are never exposed in list)
 //	GET    /secrets/{name}          – get a specific secret value
 //	PUT    /secrets/{name}          – set or update a secret value
 //	DELETE /secrets/{name}          – delete a secret
 func (e *Env) HandleSecrets(w http.ResponseWriter, r *http.Request) {
-  name := strings.TrimPrefix(r.URL.Path, "/api/v1/secrets")
-  if name == r.URL.Path {
-    name = strings.TrimPrefix(r.URL.Path, "/secrets")
-  }
+	name := strings.TrimPrefix(r.URL.Path, "/api/v1/secrets")
+	if name == r.URL.Path {
+		name = strings.TrimPrefix(r.URL.Path, "/secrets")
+	}
 	name = strings.TrimPrefix(name, "/")
 
 	switch r.Method {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -39,14 +39,14 @@ func NewServer(env *handlers.Env) http.Handler {
 	mux.Handle("/ui/playbooks", http.HandlerFunc(env.HandlePlaybooksUI))
 	mux.Handle("/ui/deployments", http.HandlerFunc(env.HandleDeploymentsUI))
 
-	mux.Handle("/playbooks", root(http.HandlerFunc(env.HandleRootPlaybooks)))
-	mux.Handle("/playbooks/", root(http.HandlerFunc(env.HandleRootPlaybooks)))
+	mux.Handle("/api/v1/playbooks", root(http.HandlerFunc(env.HandleRootPlaybooks)))
+	mux.Handle("/api/v1/playbooks/", root(http.HandlerFunc(env.HandleRootPlaybooks)))
 
-	mux.Handle("/clients", root(http.HandlerFunc(env.HandleRootClients)))
-	mux.Handle("/clients/", root(http.HandlerFunc(env.HandleRootClients)))
+	mux.Handle("/api/v1/clients", root(http.HandlerFunc(env.HandleRootClients)))
+	mux.Handle("/api/v1/clients/", root(http.HandlerFunc(env.HandleRootClients)))
 
-	mux.Handle("/deployments", root(http.HandlerFunc(env.HandleRootDeployments)))
-	mux.Handle("/deployments/", root(http.HandlerFunc(env.HandleRootDeployments)))
+	mux.Handle("/api/v1/deployments", root(http.HandlerFunc(env.HandleRootDeployments)))
+	mux.Handle("/api/v1/deployments/", root(http.HandlerFunc(env.HandleRootDeployments)))
 
 	// Artifacts are accessible by both clients (JWT) and root (Basic auth).
 	// We use a dual-auth wrapper that accepts either credential type.


### PR DESCRIPTION
This pull request standardizes the route structure for API and UI endpoints across the codebase, moving all root management APIs under `/api/v1` and browser UI pages under `/ui`. It updates documentation, handler code, UI scripts, and tests to reflect these conventions, ensuring consistency for developers and users.

Route conventions and documentation:

* Added route conventions section to `CONTRIBUTING.MD`, specifying API endpoints under `/api/v1` and UI pages under `/ui`, and requiring documentation and tests to be updated with new resources.
* Updated `README.md` and `docs/api-endpoints.md` to clarify and document the new API and UI route conventions, including examples for public/client and root management endpoints. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R147) [[3]](diffhunk://#diff-d69b7976ec8b49ff7cdf0185debe3d25dfdadaa0a024aeed091953d458718409L28-R115)

Handler and server code updates:

* Refactored handler functions and route registration in `internal/daemon/handlers/admin.go` and `internal/daemon/server.go` to use `/api/v1/playbooks`, `/api/v1/clients`, and `/api/v1/deployments` instead of legacy paths. [[1]](diffhunk://#diff-91723004ab6cf9ce2b15c6e41a910b20a52c0f145195c151661c959c31ad5b9fL23-R38) [[2]](diffhunk://#diff-91723004ab6cf9ce2b15c6e41a910b20a52c0f145195c151661c959c31ad5b9fL217-R225) [[3]](diffhunk://#diff-91723004ab6cf9ce2b15c6e41a910b20a52c0f145195c151661c959c31ad5b9fL289-R300) [[4]](diffhunk://#diff-449d4261e84c0d9b67c14859a6c09c3cc4403631e163369749c14a7e0d9945d2L42-R49)
* Updated legacy and primary API documentation in `internal/daemon/handlers/secrets.go` to clarify `/api/v1/secrets` usage.

UI scripts and tests:

* Changed all UI fetch calls and tests to use the new `/api/v1` routes for playbooks, clients, and deployments, ensuring the frontend is aligned with the backend route structure. [[1]](diffhunk://#diff-a185df05bb3173ca34f3e32255f1d86b301cd7e330ca54ef8ee896389a26a940L523-R523) [[2]](diffhunk://#diff-470163e1ca907cf94410e05e3a18e6cb1d11625e1a81042126451d196fc7913cL142-R142) [[3]](diffhunk://#diff-470163e1ca907cf94410e05e3a18e6cb1d11625e1a81042126451d196fc7913cL213-R213) [[4]](diffhunk://#diff-470163e1ca907cf94410e05e3a18e6cb1d11625e1a81042126451d196fc7913cL250-R250) [[5]](diffhunk://#diff-c97b3500b7e0b46eb1939e0c5c676e1211a2327f27c4ed5eef32dcba1066c1a3L148-R148) [[6]](diffhunk://#diff-c97b3500b7e0b46eb1939e0c5c676e1211a2327f27c4ed5eef32dcba1066c1a3L193-R193) [[7]](diffhunk://#diff-c97b3500b7e0b46eb1939e0c5c676e1211a2327f27c4ed5eef32dcba1066c1a3L209-R209) [[8]](diffhunk://#diff-c97b3500b7e0b46eb1939e0c5c676e1211a2327f27c4ed5eef32dcba1066c1a3L226-R226) [[9]](diffhunk://#diff-c97b3500b7e0b46eb1939e0c5c676e1211a2327f27c4ed5eef32dcba1066c1a3L248-R248) [[10]](diffhunk://#diff-c97b3500b7e0b46eb1939e0c5c676e1211a2327f27c4ed5eef32dcba1066c1a3L288-R291) [[11]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L346-R346) [[12]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L360-R360) [[13]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L370-R380) [[14]](diffhunk://#diff-cca3cc92558321188c8e61bdd7a7fe6ca52cb76dac2837dfe3ae4e60d5ccbb05L454-R455)