### PR TITLE
Refactor variable names for clarity and consistency

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -160,5 +160,5 @@ Release packaging matrix is defined in [.goreleaser.yml](.goreleaser.yml).
 ## Documentation expectations
 
 - Keep README focused on operators and users of the tool.
-- Put contributor and maintenance guidance in CONTRIBUTING.MD.
+- Put contributor and maintenance guidance in CONTRIBUTING.md.
 - Update examples when changing config schema or workflow behavior.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sear helps infrastructure teams roll out and manage repeatable deployments acros
 
 | For operators | For integration | For contributors |
 | --- | --- | --- |
-| [Download releases](https://github.com/marko-stanojevic/sear/releases) | [API endpoints](docs/api-endpoints.md) | [Contributing guide](CONTRIBUTING.MD) |
+| [Download releases](https://github.com/marko-stanojevic/sear/releases) | [API endpoints](docs/api-endpoints.md) | [Contributing guide](CONTRIBUTING.md) |
 | [Quick start](#quick-start) | [Playbook model](#playbook-model) | [Project docs](#documentation) |
 
 ## Why teams choose sear
@@ -138,7 +138,7 @@ Example playbook: `examples/playbook.yml`
 ## Documentation
 
 - API endpoints: [docs/api-endpoints.md](docs/api-endpoints.md)
-- Contributor and development guide: [CONTRIBUTING.MD](CONTRIBUTING.MD)
+- Contributor and development guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## API route conventions
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -207,10 +207,10 @@ func wsEndpoint(serverURL, token string) string {
 
 // ── Playbook execution ────────────────────────────────────────────────────────
 
-func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *common.WSPlaybookData) {
+func (c *Client) runPlaybook(ctx context.Context, writer *WSOutboundWriter, pd *common.WSPlaybookData) {
 	pb := pd.Playbook
-	depID := pd.DeploymentID
-	log.Printf("starting playbook %q (deployment %s, resume step %d)", pb.Name, depID, pd.ResumeStepIndex)
+	deploymentID := pd.DeploymentID
+	log.Printf("starting playbook %q (deployment %s, resume step %d)", pb.Name, deploymentID, pd.ResumeStepIndex)
 
 	flat := common.FlattenPlaybook(pb)
 
@@ -229,7 +229,7 @@ func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *
 			Type:      common.WSMsgStepStart,
 			Timestamp: time.Now(),
 			Data: common.WSStepData{
-				DeploymentID: depID,
+				DeploymentID: deploymentID,
 				JobName:      fs.JobName,
 				StepName:     stepName,
 				StepIndex:    fs.GlobalIndex,
@@ -242,7 +242,7 @@ func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *
 				Type:      common.WSMsgLog,
 				Timestamp: time.Now(),
 				Data: common.WSLogData{
-					DeploymentID: depID,
+					DeploymentID: deploymentID,
 					JobName:      fs.JobName,
 					StepIndex:    fs.GlobalIndex,
 					Level:        level,
@@ -261,7 +261,7 @@ func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *
 				Type:      common.WSMsgReboot,
 				Timestamp: time.Now(),
 				Data: common.WSRebootData{
-					DeploymentID:    depID,
+					DeploymentID:    deploymentID,
 					ResumeStepIndex: resumeAt,
 					Reason:          result.RebootReason,
 				},
@@ -281,7 +281,7 @@ func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *
 					Type:      common.WSMsgStepComplete,
 					Timestamp: time.Now(),
 					Data: common.WSStepData{
-						DeploymentID: depID,
+						DeploymentID: deploymentID,
 						JobName:      fs.JobName,
 						StepName:     stepName,
 						StepIndex:    fs.GlobalIndex,
@@ -295,7 +295,7 @@ func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *
 				Type:      common.WSMsgDeployFailed,
 				Timestamp: time.Now(),
 				Data: common.WSStepData{
-					DeploymentID: depID,
+					DeploymentID: deploymentID,
 					JobName:      fs.JobName,
 					StepName:     stepName,
 					StepIndex:    fs.GlobalIndex,
@@ -310,7 +310,7 @@ func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *
 			Type:      common.WSMsgStepComplete,
 			Timestamp: time.Now(),
 			Data: common.WSStepData{
-				DeploymentID: depID,
+				DeploymentID: deploymentID,
 				JobName:      fs.JobName,
 				StepName:     stepName,
 				StepIndex:    fs.GlobalIndex,
@@ -322,18 +322,18 @@ func (c *Client) runPlaybook(ctx context.Context, writer *wsOutboundWriter, pd *
 	writer.Send(common.WSMessage{
 		Type:      common.WSMsgDeployDone,
 		Timestamp: time.Now(),
-		Data:      common.WSStepData{DeploymentID: depID},
+		Data:      common.WSStepData{DeploymentID: deploymentID},
 	})
 }
 
-type wsOutboundWriter struct {
+type WSOutboundWriter struct {
 	ch   chan common.WSMessage
 	stop chan struct{}
 	done chan struct{}
 }
 
-func newWSOutboundWriter(ws *websocket.Conn) *wsOutboundWriter {
-	w := &wsOutboundWriter{
+func newWSOutboundWriter(ws *websocket.Conn) *WSOutboundWriter {
+	w := &WSOutboundWriter{
 		ch:   make(chan common.WSMessage, 256),
 		stop: make(chan struct{}),
 		done: make(chan struct{}),
@@ -366,7 +366,7 @@ func newWSOutboundWriter(ws *websocket.Conn) *wsOutboundWriter {
 	return w
 }
 
-func (w *wsOutboundWriter) Send(msg common.WSMessage) {
+func (w *WSOutboundWriter) Send(msg common.WSMessage) {
 	// Fast-path check: if the writer is already closed, don't block.
 	select {
 	case <-w.done:
@@ -383,7 +383,7 @@ func (w *wsOutboundWriter) Send(msg common.WSMessage) {
 	}
 }
 
-func (w *wsOutboundWriter) Stop() {
+func (w *WSOutboundWriter) Stop() {
 	close(w.stop)
 	<-w.done
 }

--- a/internal/daemon/handlers/admin.go
+++ b/internal/daemon/handlers/admin.go
@@ -57,7 +57,7 @@ func (e *Env) HandleRootPlaybooks(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "playbook not found")
 			return
 		}
-		pbYAML, err := yaml.Marshal(pb.Playbook)
+		playbookYAML, err := yaml.Marshal(pb.Playbook)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to render playbook YAML")
 			return
@@ -67,7 +67,7 @@ func (e *Env) HandleRootPlaybooks(w http.ResponseWriter, r *http.Request) {
 			"name":          pb.Name,
 			"description":   pb.Description,
 			"playbook":      pb.Playbook,
-			"playbook_yaml": string(pbYAML),
+			"playbook_yaml": string(playbookYAML),
 			"created_at":    pb.CreatedAt,
 			"updated_at":    pb.UpdatedAt,
 		})
@@ -170,11 +170,11 @@ func decodePlaybookWritePayload(r *http.Request) (store.PlaybookRecord, error) {
 	}
 
 	if strings.TrimSpace(in.PlaybookYAML) != "" {
-		var pb common.Playbook
-		if err := yaml.Unmarshal([]byte(in.PlaybookYAML), &pb); err != nil {
+		var playbook common.Playbook
+		if err := yaml.Unmarshal([]byte(in.PlaybookYAML), &playbook); err != nil {
 			return store.PlaybookRecord{}, fmt.Errorf("invalid YAML in playbook_yaml: %w", err)
 		}
-		out.Playbook = &pb
+		out.Playbook = &playbook
 	}
 
 	if out.Name == "" && out.Playbook != nil {

--- a/internal/daemon/handlers/connect.go
+++ b/internal/daemon/handlers/connect.go
@@ -187,9 +187,9 @@ func (e *Env) handleWSMessage(clientID string, data []byte) {
 			return
 		}
 		if e.Service != nil {
-			pbName := e.Service.ResolvePlaybookNameByDeployment(d.DeploymentID)
+			playbookName := e.Service.ResolvePlaybookNameByDeployment(d.DeploymentID)
 			e.Service.AppendDeploymentLog(d.DeploymentID, "", 0, common.LogLevelInfo,
-				fmt.Sprintf("playbook %q completed successfully", pbName))
+				fmt.Sprintf("playbook %q completed successfully", playbookName))
 		}
 		now := time.Now()
 		e.updateDeploy(d.DeploymentID, func(dep *common.DeploymentState) {
@@ -206,11 +206,11 @@ func (e *Env) handleWSMessage(clientID string, data []byte) {
 		if json.Unmarshal(envelope.Data, &d) != nil {
 			return
 		}
-		pbName := "playbook"
+		playbookName := "playbook"
 		if e.Service != nil {
-			pbName = e.Service.ResolvePlaybookNameByDeployment(d.DeploymentID)
+			playbookName = e.Service.ResolvePlaybookNameByDeployment(d.DeploymentID)
 		}
-		msg := fmt.Sprintf("playbook %q failed", pbName)
+		msg := fmt.Sprintf("playbook %q failed", playbookName)
 		if d.Error != "" {
 			msg = fmt.Sprintf("%s: %s", msg, d.Error)
 		}
@@ -233,8 +233,8 @@ func (e *Env) handleWSMessage(clientID string, data []byte) {
 	}
 }
 
-func (e *Env) updateDeploy(depID string, fn func(*common.DeploymentState)) {
-	dep, ok := e.Store.GetDeployment(depID)
+func (e *Env) updateDeploy(deploymentID string, fn func(*common.DeploymentState)) {
+	dep, ok := e.Store.GetDeployment(deploymentID)
 	if !ok {
 		return
 	}

--- a/internal/daemon/handlers/env.go
+++ b/internal/daemon/handlers/env.go
@@ -15,7 +15,7 @@ import (
 
 // Env bundles the dependencies shared by all handlers.
 type Env struct {
-	Store               ports.StorePort
+	Store               ports.Store
 	JWTSecret           []byte
 	RootPassword        string
 	TokenExpiryHours    int
@@ -31,11 +31,11 @@ type Env struct {
 // Hub manages all active WebSocket connections.
 type Hub struct {
 	mu    sync.RWMutex
-	conns map[string]*wsConn // clientID → connection
+	conns map[string]*WSConn // clientID → connection
 }
 
-// wsConn wraps a single client WebSocket connection with an outbound queue.
-type wsConn struct {
+// WSConn wraps a single client WebSocket connection with an outbound queue.
+type WSConn struct {
 	clientID string
 	ws       *websocket.Conn
 	send     chan []byte
@@ -44,11 +44,11 @@ type wsConn struct {
 
 // NewHub creates an empty Hub.
 func NewHub() *Hub {
-	return &Hub{conns: make(map[string]*wsConn)}
+	return &Hub{conns: make(map[string]*WSConn)}
 }
 
 // register adds (or replaces) the connection for a client.
-func (h *Hub) register(conn *wsConn) {
+func (h *Hub) register(conn *WSConn) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if old, ok := h.conns[conn.clientID]; ok {
@@ -93,9 +93,9 @@ func (h *Hub) Send(clientID string, msg common.WSMessage) bool {
 	}
 }
 
-// newWSConn creates a wsConn and starts its write pump goroutine.
-func newWSConn(clientID string, ws *websocket.Conn) *wsConn {
-	c := &wsConn{
+// newWSConn creates a WSConn and starts its write pump goroutine.
+func newWSConn(clientID string, ws *websocket.Conn) *WSConn {
+	c := &WSConn{
 		clientID: clientID,
 		ws:       ws,
 		send:     make(chan []byte, 64),
@@ -105,7 +105,7 @@ func newWSConn(clientID string, ws *websocket.Conn) *wsConn {
 	return c
 }
 
-func (c *wsConn) writePump() {
+func (c *WSConn) writePump() {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for {

--- a/internal/daemon/ports/store.go
+++ b/internal/daemon/ports/store.go
@@ -5,8 +5,8 @@ import (
 	"github.com/marko-stanojevic/sear/internal/daemon/store"
 )
 
-// StorePort defines persistence capabilities used by handler/service layers.
-type StorePort interface {
+// Store defines persistence capabilities used by handler/service layers.
+type Store interface {
 	SaveClient(c *common.Client) error
 	GetClient(id string) (*common.Client, bool)
 	ListClients() []*common.Client
@@ -40,8 +40,8 @@ type StorePort interface {
 	GetLogsForClient(clientID string) []*common.LogEntry
 }
 
-// HubPort defines websocket coordination capabilities used by services.
-type HubPort interface {
+// Hub defines websocket coordination capabilities used by services.
+type Hub interface {
 	IsConnected(clientID string) bool
 	Send(clientID string, msg common.WSMessage) bool
 }

--- a/internal/daemon/service/manager.go
+++ b/internal/daemon/service/manager.go
@@ -21,8 +21,8 @@ var (
 
 // Manager hosts daemon application-level orchestration logic.
 type Manager struct {
-	Store     ports.StorePort
-	Hub       ports.HubPort
+	Store     ports.Store
+	Hub       ports.Hub
 	ServerURL string
 }
 
@@ -61,14 +61,14 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string) {
 		return
 	}
 
-	var depID string
+	var deploymentID string
 	resumeStep := 0
 
 	if hasDep &&
 		(dep.Status == common.DeploymentStatusPending ||
 			dep.Status == common.DeploymentStatusRunning ||
 			dep.Status == common.DeploymentStatusRebooting) {
-		depID = dep.ID
+		deploymentID = dep.ID
 		resumeStep = dep.ResumeStepIndex
 		dep.Status = common.DeploymentStatusRunning
 		dep.UpdatedAt = time.Now()
@@ -79,9 +79,9 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string) {
 	} else if !hasDep ||
 		dep.Status == common.DeploymentStatusDone ||
 		dep.Status == common.DeploymentStatusFailed {
-		depID = uuid.New().String()
+		deploymentID = uuid.New().String()
 		newDep := &common.DeploymentState{
-			ID:              depID,
+			ID:              deploymentID,
 			ClientID:        clientID,
 			PlaybookID:      client.PlaybookID,
 			Status:          common.DeploymentStatusRunning,
@@ -90,7 +90,7 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string) {
 			UpdatedAt:       time.Now(),
 		}
 		if err := m.Store.SaveDeployment(newDep); err != nil {
-			fmt.Printf("failed to save new deployment %s for client %s: %v\n", depID, clientID, err)
+			fmt.Printf("failed to save new deployment %s for client %s: %v\n", deploymentID, clientID, err)
 			return
 		}
 	} else {
@@ -103,18 +103,18 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string) {
 		return
 	}
 
-	pbName := pb.Name
+	playbookName := pb.Name
 	if pb.Playbook != nil && pb.Playbook.Name != "" {
-		pbName = pb.Playbook.Name
+		playbookName = pb.Playbook.Name
 	}
-	m.AppendDeploymentLog(depID, "", 0, common.LogLevelInfo,
-		fmt.Sprintf("starting playbook %q (deployment %s, resume step %d)", pbName, depID, resumeStep))
+	m.AppendDeploymentLog(deploymentID, "", 0, common.LogLevelInfo,
+		fmt.Sprintf("starting playbook %q (deployment %s, resume step %d)", playbookName, deploymentID, resumeStep))
 
 	m.Hub.Send(clientID, common.WSMessage{
 		Type:      common.WSMsgPlaybook,
 		Timestamp: time.Now(),
 		Data: common.WSPlaybookData{
-			DeploymentID:     depID,
+			DeploymentID:     deploymentID,
 			Playbook:         pb.Playbook,
 			ResumeStepIndex:  resumeStep,
 			Secrets:          m.Store.AllSecrets(),
@@ -138,17 +138,17 @@ func (m *Manager) AppendDeploymentLog(deploymentID, jobName string, stepIndex in
 }
 
 func (m *Manager) ResolvePlaybookNameByDeployment(deploymentID string) string {
-	pbName := "playbook"
+	playbookName := "playbook"
 	if dep, ok := m.Store.GetDeployment(deploymentID); ok {
 		if pb, ok := m.Store.GetPlaybook(dep.PlaybookID); ok {
 			if pb.Playbook != nil && pb.Playbook.Name != "" {
-				pbName = pb.Playbook.Name
+				playbookName = pb.Playbook.Name
 			} else if pb.Name != "" {
-				pbName = pb.Name
+				playbookName = pb.Name
 			}
 		}
 	}
-	return pbName
+	return playbookName
 }
 
-var _ ports.StorePort = (*store.Store)(nil)
+var _ ports.Store = (*store.Store)(nil)

--- a/internal/daemon/store/store.go
+++ b/internal/daemon/store/store.go
@@ -39,11 +39,11 @@ type Store struct {
 	artifacts   map[string]*common.Artifact
 	secrets     map[string]string // client secrets (name→value)
 
-	// logMusMu protects logMus; logMus holds a per-deployment mutex so that
+	// logMutexesMu protects logMutexes; logMutexes holds a per-deployment mutex so that
 	// concurrent log reads/writes for the same deployment are serialised without
 	// blocking unrelated deployments.
-	logMusMu sync.Mutex
-	logMus   map[string]*sync.Mutex
+	logMutexesMu sync.Mutex
+	logMutexes   map[string]*sync.Mutex
 }
 
 // snapshot is the structure serialised to state.json.
@@ -76,7 +76,7 @@ func New(dir string, logsDir string) (*Store, error) {
 		playbooks:   make(map[string]*PlaybookRecord),
 		artifacts:   make(map[string]*common.Artifact),
 		secrets:     make(map[string]string),
-		logMus:      make(map[string]*sync.Mutex),
+		logMutexes:  make(map[string]*sync.Mutex),
 	}
 	if err := s.load(); err != nil {
 		return nil, err
@@ -162,18 +162,18 @@ func normalizePlatform(platform common.PlatformType, osName string, metadata map
 }
 
 func platformFromOS(osName string, metadata map[string]string) common.PlatformType {
-	osv := strings.ToLower(strings.TrimSpace(osName))
-	if osv == "" && metadata != nil {
-		osv = strings.ToLower(strings.TrimSpace(metadata["os"]))
-		if osv == "" {
-			osv = strings.ToLower(strings.TrimSpace(metadata["type"]))
+	normalizedOS := strings.ToLower(strings.TrimSpace(osName))
+	if normalizedOS == "" && metadata != nil {
+		normalizedOS = strings.ToLower(strings.TrimSpace(metadata["os"]))
+		if normalizedOS == "" {
+			normalizedOS = strings.ToLower(strings.TrimSpace(metadata["type"]))
 		}
-		if osv == "" {
-			osv = strings.ToLower(strings.TrimSpace(metadata["os_type"]))
+		if normalizedOS == "" {
+			normalizedOS = strings.ToLower(strings.TrimSpace(metadata["os_type"]))
 		}
 	}
 
-	switch osv {
+	switch normalizedOS {
 	case "darwin":
 		return common.PlatformMac
 	case "windows":
@@ -531,15 +531,15 @@ func (s *Store) logPath(deploymentID string) string {
 	return filepath.Join(s.logsDir, deploymentID+".json")
 }
 
-// logMu returns (and lazily creates) the mutex for a specific deployment ID.
-func (s *Store) logMu(depID string) *sync.Mutex {
-	s.logMusMu.Lock()
-	defer s.logMusMu.Unlock()
-	if mu, ok := s.logMus[depID]; ok {
+// logMutex returns (and lazily creates) the mutex for a specific deployment ID.
+func (s *Store) logMutex(deploymentID string) *sync.Mutex {
+	s.logMutexesMu.Lock()
+	defer s.logMutexesMu.Unlock()
+	if mu, ok := s.logMutexes[deploymentID]; ok {
 		return mu
 	}
 	mu := &sync.Mutex{}
-	s.logMus[depID] = mu
+	s.logMutexes[deploymentID] = mu
 	return mu
 }
 
@@ -551,21 +551,21 @@ func (s *Store) AppendLogs(entries []*common.LogEntry) error {
 	for _, e := range entries {
 		byDep[e.DeploymentID] = append(byDep[e.DeploymentID], e)
 	}
-	for depID, batch := range byDep {
-		if err := s.appendDepLogs(depID, batch); err != nil {
+	for deploymentID, batch := range byDep {
+		if err := s.appendDeploymentLogs(deploymentID, batch); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Store) appendDepLogs(depID string, entries []*common.LogEntry) error {
-	mu := s.logMu(depID)
+func (s *Store) appendDeploymentLogs(deploymentID string, entries []*common.LogEntry) error {
+	mu := s.logMutex(deploymentID)
 	mu.Lock()
 	defer mu.Unlock()
 
-	path := s.logPath(depID)
-	existing := s.readDepLogsLocked(path)
+	path := s.logPath(deploymentID)
+	existing := s.readDeploymentLogsLocked(path)
 	existing = append(existing, entries...)
 	data, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {
@@ -578,9 +578,9 @@ func (s *Store) appendDepLogs(depID string, entries []*common.LogEntry) error {
 	return os.Rename(tmp, path)
 }
 
-// readDepLogsLocked reads log entries from path. The caller must hold the
+// readDeploymentLogsLocked reads log entries from path. The caller must hold the
 // per-deployment log mutex.
-func (s *Store) readDepLogsLocked(path string) []*common.LogEntry {
+func (s *Store) readDeploymentLogsLocked(path string) []*common.LogEntry {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -592,28 +592,28 @@ func (s *Store) readDepLogsLocked(path string) []*common.LogEntry {
 
 // GetLogsForDeployment returns all log entries for a specific deployment.
 func (s *Store) GetLogsForDeployment(deploymentID string) []*common.LogEntry {
-	mu := s.logMu(deploymentID)
+	mu := s.logMutex(deploymentID)
 	mu.Lock()
 	defer mu.Unlock()
-	return s.readDepLogsLocked(s.logPath(deploymentID))
+	return s.readDeploymentLogsLocked(s.logPath(deploymentID))
 }
 
 // GetLogsForClient returns all log entries for every deployment of a client.
 func (s *Store) GetLogsForClient(clientID string) []*common.LogEntry {
 	s.mu.RLock()
-	depIDs := make([]string, 0)
+	deploymentIDs := make([]string, 0)
 	for _, d := range s.deployments {
 		if d.ClientID == clientID {
-			depIDs = append(depIDs, d.ID)
+			deploymentIDs = append(deploymentIDs, d.ID)
 		}
 	}
 	s.mu.RUnlock()
 
 	var out []*common.LogEntry
-	for _, id := range depIDs {
-		mu := s.logMu(id)
+	for _, deploymentID := range deploymentIDs {
+		mu := s.logMutex(deploymentID)
 		mu.Lock()
-		out = append(out, s.readDepLogsLocked(s.logPath(id))...)
+		out = append(out, s.readDeploymentLogsLocked(s.logPath(deploymentID))...)
 		mu.Unlock()
 	}
 	return out


### PR DESCRIPTION
This pull request focuses on improving naming consistency and clarity throughout the codebase, primarily by standardizing variable, type, and interface names. It also corrects documentation references and updates code to use these new conventions. The changes are grouped below by theme.

Naming consistency improvements:

* Standardized variable names such as replacing `depID` and `pbName` with `deploymentID` and `playbookName` in multiple files, improving readability and clarity. [[1]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L210-R213) [[2]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L232-R232) [[3]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L245-R245) [[4]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L264-R264) [[5]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L284-R284) [[6]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L298-R298) [[7]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L313-R313) [[8]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L325-R336) [[9]](diffhunk://#diff-f6a5740f84ed760a50e81e158affc633303702e02e3ee74640c2f070fb859036L64-R71) [[10]](diffhunk://#diff-f6a5740f84ed760a50e81e158affc633303702e02e3ee74640c2f070fb859036L82-R84) [[11]](diffhunk://#diff-f6a5740f84ed760a50e81e158affc633303702e02e3ee74640c2f070fb859036L93-R93) [[12]](diffhunk://#diff-f6a5740f84ed760a50e81e158affc633303702e02e3ee74640c2f070fb859036L106-R117) [[13]](diffhunk://#diff-f6a5740f84ed760a50e81e158affc633303702e02e3ee74640c2f070fb859036L141-R154) [[14]](diffhunk://#diff-91723004ab6cf9ce2b15c6e41a910b20a52c0f145195c151661c959c31ad5b9fL60-R60) [[15]](diffhunk://#diff-91723004ab6cf9ce2b15c6e41a910b20a52c0f145195c151661c959c31ad5b9fL70-R70) [[16]](diffhunk://#diff-91723004ab6cf9ce2b15c6e41a910b20a52c0f145195c151661c959c31ad5b9fL173-R177) [[17]](diffhunk://#diff-a185df05bb3173ca34f3e32255f1d86b301cd7e330ca54ef8ee896389a26a940L190-R192) [[18]](diffhunk://#diff-a185df05bb3173ca34f3e32255f1d86b301cd7e330ca54ef8ee896389a26a940L209-R213) [[19]](diffhunk://#diff-a185df05bb3173ca34f3e32255f1d86b301cd7e330ca54ef8ee896389a26a940L236-R237)
* Renamed types and interfaces for clarity: `wsOutboundWriter` → `WSOutboundWriter`, `wsConn` → `WSConn`, `StorePort` → `Store`, and `HubPort` → `Hub` across relevant files. (F3225d70L160R160, [[1]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L325-R336) [[2]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L369-R369) [[3]](diffhunk://#diff-3b1f8149deb45d304c69c856bcd1b9b628961fb6000486cb39172a99cb8de514L386-R386) [[4]](diffhunk://#diff-79af9ff334da2b829191b85013dc04d5ea4f210d7350bf80cad46dc52edcf769L18-R18) [[5]](diffhunk://#diff-79af9ff334da2b829191b85013dc04d5ea4f210d7350bf80cad46dc52edcf769L34-R38) [[6]](diffhunk://#diff-79af9ff334da2b829191b85013dc04d5ea4f210d7350bf80cad46dc52edcf769L47-R51) [[7]](diffhunk://#diff-79af9ff334da2b829191b85013dc04d5ea4f210d7350bf80cad46dc52edcf769L96-R98) [[8]](diffhunk://#diff-79af9ff334da2b829191b85013dc04d5ea4f210d7350bf80cad46dc52edcf769L108-R108) [[9]](diffhunk://#diff-f5dc93c8f688b91d8b899189ec588819a311cc2a6227baada24b23445822a09bL8-R9) [[10]](diffhunk://#diff-f5dc93c8f688b91d8b899189ec588819a311cc2a6227baada24b23445822a09bL43-R44) [[11]](diffhunk://#diff-f6a5740f84ed760a50e81e158affc633303702e02e3ee74640c2f070fb859036L24-R25)

Documentation corrections:

* Fixed references to the contributing guide in `README.md` and `CONTRIBUTING.MD` to use the correct filename casing (`CONTRIBUTING.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L141-R141) [[3]](diffhunk://#diff-c358316cc7791c98cffda448d7cb258e6096712c89a67fdafa5cd82168315fd9L163-R163)

These changes collectively make the codebase easier to read, maintain, and contribute to by enforcing consistent naming conventions and correcting documentation references.