### PR TITLE
Add reusable Copilot skills

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,6 +130,20 @@ Release artifacts and matrix are configured in `.goreleaser.yml`.
 - **Auth split**: root endpoints use HTTP Basic auth, client endpoints use JWT.
 - **Logs storage**: deployment logs are persisted per deployment in `logsDir`, not inside `state.json`.
 
+## Available Skills
+
+The repository provides reusable Copilot skills in `.github/skills`:
+
+- `code-interpretation`: Read AI-generated code and understand unfamiliar codebase structure/flow.
+- `code-review`: Find bugs, regressions, and missing tests with severity-ranked findings.
+- `refactor`: Perform behavior-preserving restructuring and cleanup.
+- `security-audit`: Audit for security risks, insecure defaults, and hardening gaps.
+- `developer-experience`: Improve local workflow, CI, tasks, and onboarding setup.
+- `documentation`: Update documentation from code additions, changes, and deletions.
+- `design-compliance`: Verify design patterns, enforce SOLID/clean architecture, detect bad practices, and guide developers.
+- `test-driven-development`: Write unit tests, practice TDD red/green/refactor cycles, and close coverage gaps.
+- `architecture-awareness`: Understand project architecture, runtime usage, and how to add or modify features safely.
+
 ## Trust These Instructions
 
 Trust the information in this file. Only search the codebase if the information here is incomplete or appears incorrect.

--- a/.github/skills/architecture-awareness/SKILL.md
+++ b/.github/skills/architecture-awareness/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: architecture-awareness
+description: "Use when understanding project architecture, runtime behavior, usage patterns, or planning new features and modifications. Triggers: understand architecture, how does this project work, where do I add a feature, how do I modify this behavior, explain system design, trace data flow end-to-end, map service boundaries, onboarding to codebase. Produces an architectural overview, usage map, extension points, and a concrete guide for adding or modifying features safely."
+---
+
+# Architecture Awareness Skill
+
+## Goal
+Give developers a clear, accurate picture of how the project is structured, how it runs in practice, and how to confidently add or modify features without breaking existing behavior.
+
+## Scope
+This skill is for:
+- Understanding the overall architecture and component responsibilities.
+- Mapping how the system is deployed and used end-to-end.
+- Identifying the right place to add a new feature or change an existing one.
+- Locating integration points, seams, and extension mechanisms.
+- Surfacing constraints (performance, security, compatibility) that affect design decisions.
+- Onboarding new developers to the codebase quickly.
+
+## Output Contract
+Return results in this order:
+
+1. Architecture overview (layers, major components, and boundaries).
+2. Runtime usage map (how the system starts, processes a request, and terminates).
+3. Component responsibility table.
+4. Extension guide (where and how to add or change features).
+5. Constraints and risks for the planned change.
+6. Recommended reading path.
+
+## Workflow
+
+1. Establish architecture style
+- Identify the architectural pattern (layered, clean, ports/adapters, event-driven).
+- Map top-level layers: entrypoints, coordination, domain, persistence, shared types.
+- Note cross-cutting concerns: auth, logging, error handling, config.
+
+2. Map runtime usage
+- Trace the lifecycle: startup, request handling, state transitions, teardown.
+- Follow at least one critical flow end-to-end from entrypoint to persistence.
+- Identify where clients, services, stores, and external systems interact.
+
+3. Build a component responsibility table
+- List each major package/module.
+- State its single responsibility and its allowed dependencies.
+- Flag packages with unclear or mixed responsibilities.
+
+4. Identify extension points
+- Locate interfaces, registries, and plugin points explicitly designed for extension.
+- Identify implicit seams where new behavior can be inserted safely.
+- Note conventions used by existing features that new ones should follow.
+
+5. Plan the feature addition or modification
+- Identify the exact layers and files that need to change.
+- Confirm dependency direction stays correct for the change.
+- Note what tests need to be written or updated.
+- Surface any cross-cutting impact (config, auth, docs, examples).
+
+6. Surface constraints
+- List invariants that must be preserved.
+- Call out security, concurrency, and persistence considerations.
+- Flag backward-compatibility risks for changes to shared contracts.
+
+## Quality Bar
+- All claims about architecture must be traceable to actual code.
+- Distinguish design intent from current implementation reality.
+- Provide enough specificity that a developer can start coding immediately.
+- Separate stable architectural facts from areas of known complexity or debt.
+
+## Recommended Artifacts to Inspect
+- Entrypoints (`cmd/`) for startup and config wiring.
+- Handler layer for API contracts and auth enforcement.
+- Service/manager layer for orchestration and business rules.
+- Store/persistence layer for state shape and durability guarantees.
+- Shared types (`internal/common`) for cross-boundary contracts.
+- Examples and config files for intended usage patterns.
+
+## Recommended Model
+- **Best fit**: Reasoning model.
+- System-level thinking to map layers, boundaries, and dependency flows.
+- Planning capability to identify the right extension points and impact of changes.
+- Large context window to hold multiple files and reason about cross-module interactions.
+
+## Non-Goals
+- Redesigning architecture without explicit request.
+- Proposing large-scale refactors as a prerequisite to feature work.
+- Speculating about requirements not present in the codebase or stated by the user.

--- a/.github/skills/code-interpretation/SKILL.md
+++ b/.github/skills/code-interpretation/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: code-interpretation
+description: "Use when reading AI-generated code or understanding an unfamiliar codebase. Triggers: explain generated code, map architecture, trace execution flow, identify module responsibilities, understand dependencies, summarize file purpose. Produces a clear mental model, flow maps, and actionable next reading steps."
+---
+
+# Code Interpretation Skill
+
+## Goal
+Help users quickly understand generated code and the broader codebase with accurate, evidence-backed explanations.
+
+## Scope
+This skill is for:
+- Interpreting AI-generated code for correctness, intent, and maintainability.
+- Explaining existing modules, interfaces, and file responsibilities.
+- Mapping execution flow across handlers, services, stores, and clients.
+- Summarizing dependency relationships and data movement.
+- Turning large code areas into concise learning paths.
+
+## Output Contract
+Return results in this order:
+
+1. High-level summary.
+2. Component map.
+3. Execution flow (entrypoints to outcomes).
+4. Key assumptions and risks.
+5. Suggested next files/functions to read.
+
+## Workflow
+
+1. Establish context
+- Identify user goal: bug fix, feature work, review, onboarding, or refactor.
+- Detect relevant entrypoints and primary packages.
+
+2. Build a component map
+- List major modules and each module's responsibility.
+- Note boundaries: API layer, domain/service layer, persistence, shared types.
+
+3. Trace important flows
+- Follow one or two critical paths end-to-end.
+- Capture where data is validated, transformed, persisted, and emitted.
+
+4. Interpret generated code safely
+- Explain what the code does line-by-line only where needed.
+- Call out unclear naming, hidden coupling, and unhandled error paths.
+
+5. Surface risks and confidence
+- Distinguish verified behavior from assumptions.
+- Highlight test coverage gaps and likely regression areas.
+
+6. Provide learning path
+- Recommend a short sequence of files/functions to read next.
+- Include concrete questions the user should answer while reading.
+
+## Quality Bar
+- Explanations must be anchored to actual code locations.
+- Keep summaries concise, then drill down only where useful.
+- Prefer behavior and data-flow explanations over restating syntax.
+- Separate facts from interpretation.
+
+## Recommended Model
+- **Best fit**: Language model.
+- Strong language comprehension and summarization for translating code structure into clear explanations.
+- Broad context window to hold multiple files and trace cross-module flows.
+- Reasoning ability to separate facts from assumptions.
+
+## Non-Goals
+- Performing broad refactors unless requested.
+- Guessing behavior not supported by code evidence.
+- Rewriting architecture during explanation tasks.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: code-review
+description: "Use when reviewing code changes, pull requests, regressions, or test gaps. Triggers: review, code review, PR review, audit changes, find bugs, risks, regressions, missing tests, unsafe behavior, compatibility issues. Produces severity-ranked findings with file/line evidence and concrete fixes."
+---
+
+# Code Review Skill
+
+## Goal
+Perform a practical engineering review focused on correctness, risk, and regressions.
+
+## Output Contract
+Always return results in this order:
+
+1. Findings first, ordered by severity.
+2. Open questions and assumptions.
+3. Brief change summary (only after findings).
+4. Suggested next actions.
+
+If no issues are found, explicitly say so and call out remaining risk or test gaps.
+
+## Severity Model
+- Critical: Security, data loss, auth bypass, destructive behavior, severe outage risk.
+- High: Behavioral regression, concurrency bugs, broken error handling, invalid state transitions.
+- Medium: Edge-case bugs, weak validation, incomplete tests for key branches.
+- Low: Maintainability issues, unclear naming, missing comments for complex logic.
+
+## Review Workflow
+
+1. Gather context
+- Check changed files and affected packages.
+- Identify entry points, state mutation paths, and IO boundaries.
+
+2. Validate behavior
+- Compare intended behavior vs implemented behavior.
+- Focus on error paths, nil/empty handling, and branching logic.
+
+3. Check reliability
+- Concurrency safety.
+- Resource lifecycle correctness (files/sockets/goroutines).
+- Timeout and retry behavior.
+
+4. Check compatibility and persistence
+- Config and schema assumptions.
+- Persistent-state readers/writers and migration-sensitive code.
+
+5. Check tests
+- Confirm tests cover happy path and negative paths.
+- Look for missing race-sensitive and boundary tests.
+
+## Go-Specific Checklist
+- Error values are wrapped or compared correctly.
+- Context cancellation is honored in blocking paths.
+- No goroutine leaks.
+- Deferred cleanup order is safe.
+- Maps/slices are not mutated unsafely across goroutines.
+- HTTP status and auth behavior are consistent.
+- Time handling is deterministic where required.
+
+## Evidence Rules
+For each finding include:
+- Severity.
+- Why it matters.
+- Exact file and line reference.
+- Minimal fix recommendation.
+- Test recommendation (if applicable).
+
+## Repo Defaults (sear)
+When useful for validation, use:
+- go test ./... -v -count=1
+- go test ./... -race -count=1
+- go test ./internal/daemon/handlers/...
+- go test ./internal/daemon/store/...
+
+Prioritize review of:
+- internal/daemon/handlers
+- internal/daemon/service
+- internal/daemon/store
+- internal/client
+
+## Recommended Model
+- **Best fit**: Coding + reasoning model.
+- Code fluency to read idiomatic Go and detect logic errors and anti-patterns.
+- Reasoning ability to assess exploitability, regression risk, and missing test cases.
+- Structured output discipline for severity-ranked findings with evidence.
+
+## What Not To Do
+- Do not lead with a summary before findings.
+- Do not report style-only nits as primary issues.
+- Do not claim certainty without code evidence.
+- Do not skip testing implications for risky changes.

--- a/.github/skills/design-compliance/SKILL.md
+++ b/.github/skills/design-compliance/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: design-compliance
+description: "Use when validating architecture and code quality against design patterns, SOLID and clean architecture principles, core programming fundamentals, and maintainability standards. Triggers: design review, architecture conformance, SOLID check, clean architecture audit, bad practice detection, code quality guidance. Produces compliance findings and actionable developer guidance."
+---
+
+# Design Compliance Skill
+
+## Goal
+Verify that implementation choices align with sound design practices and guide developers toward maintainable, extensible, and testable code.
+
+## Scope
+This skill is for:
+- Verifying use of appropriate design patterns and avoiding unnecessary pattern complexity.
+- Enforcing design principles (SOLID and clean architecture boundaries).
+- Checking core programming fundamentals (cohesion, coupling, naming, error handling, and testability).
+- Detecting bad practices (god objects, hidden side effects, duplicated logic, leaky abstractions).
+- Providing practical guidance developers can apply immediately.
+
+## Output Contract
+Return results in this order:
+
+1. Compliance summary.
+2. Findings by severity (critical, major, minor) with file evidence.
+3. Principles/patterns violated or satisfied.
+4. Recommended remediations with concrete refactor steps.
+5. Coaching notes for developers (what to learn/apply next).
+
+## Workflow
+
+1. Define review boundary
+- Identify target modules, services, handlers, and interfaces under review.
+- Establish expected architectural style (layered, clean architecture, ports/adapters).
+
+2. Verify design patterns
+- Confirm pattern intent matches implementation (for example strategy, factory, adapter).
+- Flag anti-pattern usage and pattern misuse.
+
+3. Enforce principles
+- SOLID checks:
+  - Single responsibility and separation of concerns.
+  - Open/closed via extension points instead of repeated branching edits.
+  - Liskov substitution behavior safety.
+  - Interface segregation and minimal contracts.
+  - Dependency inversion at module boundaries.
+- Clean architecture checks:
+  - Dependency direction toward core domain.
+  - Framework and transport concerns isolated from business logic.
+  - Ports/interfaces used where boundaries are required.
+
+4. Check fundamentals
+- Cohesion and coupling balance.
+- Readability, naming clarity, and duplication control.
+- Error handling consistency and boundary validation.
+- Testability of units and seams for mocks/fakes.
+
+5. Detect bad practices
+- Large, multi-purpose modules with unclear ownership.
+- Shared mutable state without safe control.
+- Premature abstraction and speculative generality.
+- Hidden I/O or side effects in low-level helpers.
+
+6. Guide developers
+- Recommend small, safe refactor sequence with low regression risk.
+- Suggest tests to protect behavior before changes.
+- Provide clear before/after outcomes.
+
+## Quality Bar
+- Every finding maps to a specific principle or pattern expectation.
+- Recommendations are incremental and behavior-preserving unless otherwise stated.
+- Advice is practical for current codebase constraints.
+- Distinguish style preferences from true design risks.
+
+## Recommended Model
+- **Best fit**: Reasoning model.
+- Principle recall and application for SOLID, clean architecture, and design patterns.
+- Structured analysis to rank findings by severity and map to specific violations.
+- Coaching capability to produce actionable, incremental guidance for developers.
+
+## Non-Goals
+- Rewriting architecture without stakeholder request.
+- Introducing patterns where simple code is sufficient.
+- Blocking delivery for non-critical stylistic disagreements.

--- a/.github/skills/developer-experience/SKILL.md
+++ b/.github/skills/developer-experience/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: developer-experience
+description: "Use when setting up or improving development workflow and team DX. Triggers: developer workflow setup, tasks setup, CI/CD pipeline setup, devcontainer setup, VS Code settings setup, onboarding automation, local development environment, workspace tooling standardization. Produces practical setup changes with validation and run instructions."
+---
+
+# Developer Experience Skill
+
+## Goal
+Create or improve a reliable developer workflow across local development and CI.
+
+## Scope
+This skill is for:
+- VS Code tasks and workspace automation.
+- CI/CD pipelines and validation steps.
+- Devcontainer configuration.
+- Workspace settings for consistent behavior.
+- Onboarding quality-of-life improvements.
+
+## Output Contract
+Return results in this order:
+
+1. Setup summary.
+2. Files created/updated.
+3. Validation steps and commands.
+4. Follow-up recommendations.
+
+## Workflow
+
+1. Assess current workflow
+- Detect existing tasks, CI files, devcontainer files, and workspace settings.
+- Identify gaps in build, test, lint, and run flows.
+
+2. Propose minimal standardization
+- Add or update only what is needed.
+- Preserve current conventions and existing commands where possible.
+
+3. Implement setup
+- Tasks: create clear build/test/lint/run tasks.
+- Pipelines: add deterministic CI checks with explicit steps.
+- Devcontainer: provide reproducible toolchain and extensions.
+- VS Code settings: include editor and formatting defaults relevant to the repo.
+
+4. Validate
+- Run the key tasks or commands locally where possible.
+- Confirm CI config syntax if tooling is available.
+
+5. Document usage
+- Provide quick start commands and task names.
+
+## Quality Bar
+- Commands must be executable as written.
+- Setup should be deterministic and portable.
+- Avoid introducing unrelated dependencies.
+- Keep changes explicit and reviewable.
+
+## Recommended Defaults for Go Repos
+- Build: go build ./...
+- Test: go test ./... -v -count=1
+- Race test (optional where available): go test ./... -race -count=1
+- Vet: go vet ./...
+- Tidy: go mod tidy
+
+## CI Considerations
+- Cache Go modules and build cache where supported.
+- Fail fast on lint/test/build errors.
+- Keep pipeline readable with short, named steps.
+
+## Devcontainer Considerations
+- Pin a stable Go toolchain.
+- Install required extensions for Go and YAML.
+- Ensure working directory and mount behavior are explicit.
+
+## Recommended Model
+- **Best fit**: Coding model.
+- Config and script generation for tasks, pipelines, and devcontainer files.
+- Toolchain knowledge (Go, Docker, CI systems) to produce valid, runnable setups.
+- Attention to platform-specific syntax (PowerShell, bash, YAML) depending on target environment.
+
+## Non-Goals
+- Rewriting project architecture.
+- Adding heavy platform-specific tooling without request.
+- Replacing existing workflows that already satisfy team requirements.

--- a/.github/skills/documentation/SKILL.md
+++ b/.github/skills/documentation/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: documentation
+description: "Use when code changes require documentation updates. Triggers: feature added, behavior changed, endpoint modified, config changed, flags added/removed, files deleted, refactor with user-visible impact, release notes preparation. Produces accurate doc updates mapped directly to additions/changes/deletions in code."
+---
+
+# Documentation Sync Skill
+
+## Goal
+Keep documentation accurate and current by translating code additions, modifications, and deletions into concrete doc updates.
+
+## Scope
+This skill is for:
+- Updating README, API docs, and operation guides after code changes.
+- Generating changelog and migration notes from merged deltas.
+- Detecting stale docs when code paths, flags, endpoints, or configs changed.
+- Capturing behavior, defaults, and compatibility impacts.
+- Removing obsolete documentation for deleted code paths.
+
+## Output Contract
+Return results in this order:
+
+1. Change summary (adds/changes/deletes).
+2. Doc impact matrix (code area -> doc file/section).
+3. Proposed edits (exact text snippets or patch plan).
+4. Verification checklist.
+5. Follow-up docs still missing.
+
+## Workflow
+
+1. Gather code deltas
+- Inspect changed, added, and deleted files.
+- Classify each change as behavior, API, config, CLI, runtime, or internal-only.
+
+2. Determine documentation impact
+- Map each code change to affected docs (README, docs/, examples, changelog).
+- Mark severity: required update, optional clarification, or no user-facing impact.
+
+3. Draft doc updates
+- Write concise, user-facing descriptions of what changed and why.
+- Include examples for new/changed usage and remove obsolete examples.
+- Add migration guidance when behavior or defaults changed.
+
+4. Apply consistency checks
+- Ensure command names, flags, endpoints, and config keys match code exactly.
+- Ensure terminology is consistent across all docs.
+
+5. Validate completeness
+- Confirm every high-impact code change has matching doc updates.
+- Flag unknowns or missing implementation details as TODO questions.
+
+## Quality Bar
+- Documentation statements must be traceable to current code.
+- Prefer minimal, targeted edits over broad rewrites.
+- Keep wording concrete and testable.
+- Clearly distinguish breaking changes from non-breaking improvements.
+
+## Recommended Documentation Targets
+- `README.md` for quick start and common workflows.
+- `docs/api-endpoints.md` for contract-level API behavior.
+- `examples/` files when configuration or usage changed.
+- `CHANGELOG.md` (if present) for release-facing change tracking.
+
+## Recommended Model
+- **Best fit**: Language model.
+- Strong prose generation and editing for clear, developer-facing writing.
+- Ability to summarize code diffs and translate technical changes into readable language.
+- Consistency checking across doc files for unified terminology and style.
+
+## Non-Goals
+- Inventing behavior not implemented in code.
+- Rewording entire docs without change-driven need.
+- Replacing architecture docs unless requested.

--- a/.github/skills/refactor/SKILL.md
+++ b/.github/skills/refactor/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: refactor
+description: "Use when restructuring code without changing behavior. Triggers: refactor, cleanup, simplify, extract method, rename symbol, reduce duplication, improve readability, improve maintainability, technical debt cleanup. Produces behavior-preserving code changes with tests and risk notes."
+---
+
+# Refactor Skill
+
+## Goal
+Improve structure, readability, and maintainability while preserving runtime behavior.
+
+## Refactor Contract
+Always preserve:
+- Public API behavior unless explicitly requested.
+- Input/output semantics.
+- Error and status-code behavior.
+- Persistence and protocol compatibility unless explicitly changed.
+
+## Output Contract
+Return results in this order:
+
+1. Refactor summary.
+2. Behavior-preservation checks performed.
+3. Risk notes.
+4. Follow-up opportunities.
+
+## Refactor Workflow
+
+1. Baseline
+- Identify affected files and call paths.
+- Run or inspect existing tests for the target area.
+
+2. Refactor plan
+- Prefer small, isolated changes.
+- Choose safe transforms first:
+  - Extract helper functions.
+  - Remove duplication.
+  - Improve naming.
+  - Tighten function boundaries.
+  - Simplify conditionals.
+
+3. Apply changes
+- Keep edits minimal and local.
+- Avoid unrelated formatting churn.
+- Add concise comments only where complexity warrants.
+
+4. Verify behavior
+- Re-run impacted tests first, then broader tests as needed.
+- Validate key negative paths and boundary conditions.
+
+5. Report
+- Explain what changed structurally.
+- Confirm what behavior remained unchanged.
+- Note any residual risk.
+
+## Go Refactor Checklist
+- Keep error wrapping/comparisons intact.
+- Preserve context cancellation behavior.
+- Preserve goroutine lifecycle and synchronization.
+- Preserve HTTP handlers and status codes.
+- Preserve serialization tags and field names.
+- Preserve storage schema and migration assumptions unless requested.
+
+## Safety Rules
+- Do not silently alter auth, retry, timeout, or persistence behavior.
+- Do not rename externally consumed API fields without explicit request.
+- Do not remove tests that protect behavior.
+- Prefer adding tests when refactoring complex branches.
+
+## Repo Defaults (sear)
+For validation, prefer:
+- go test ./... -v -count=1
+- go test ./internal/daemon/handlers/...
+- go test ./internal/daemon/store/...
+- go test ./internal/client/...
+
+For race-sensitive refactors where available:
+- go test ./... -race -count=1
+
+## Recommended Model
+- **Best fit**: Coding + reasoning model.
+- Code generation capability to produce idiomatic, compiling refactored code.
+- Reasoning ability to verify behavior is preserved and no invariants are broken.
+- Test awareness to validate refactor safety before and after.
+
+## Non-Goals
+- Feature additions.
+- Behavioral redesign.
+- Large architecture rewrites without explicit direction.

--- a/.github/skills/security-audit/SKILL.md
+++ b/.github/skills/security-audit/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: security-audit
+description: "Use when reviewing code for security issues or running security scans. Triggers: security audit, security review, security scan, vuln scan, vulnerability audit, auth bypass check, secrets exposure, injection risk, insecure defaults, hardening review. Produces severity-ranked findings with exploitability notes and concrete remediation steps."
+---
+
+# Security Review/Scan Skill
+
+## Goal
+Find and prioritize security risks in code and configuration, then propose concrete, low-risk fixes.
+
+## Output Contract
+Always return results in this order:
+
+1. Findings first, ordered by severity.
+2. Exploitability and impact notes.
+3. Remediation steps (minimal and practical).
+4. Verification/tests to confirm fixes.
+
+If no issues are found, state that explicitly and include residual risk.
+
+## Severity Model
+- Critical: Remote code execution, auth bypass, privilege escalation, plaintext secret leakage with immediate abuse path.
+- High: Injection risks, broken access control, weak token handling, insecure transport or credential storage.
+- Medium: Unsafe defaults, missing validation/sanitization, weak error handling that exposes internals.
+- Low: Hardening gaps, defense-in-depth improvements, missing security-focused tests.
+
+## Review Workflow
+
+1. Scope and surfaces
+- Identify trust boundaries, inputs, auth entry points, and state-changing endpoints.
+- Map data flow: input -> validation -> storage -> output/logging.
+
+2. Static security review
+- Check authn/authz logic.
+- Check secrets handling and logging.
+- Check input validation and parser usage.
+- Check file/network/process boundaries.
+
+3. Security scanning
+- Dependency vulnerabilities.
+- Common Go security patterns (unsafe command execution, path traversal, insecure randomness/crypto usage mistakes).
+
+4. Prioritize and fix
+- Prefer minimal, behavior-preserving remediations.
+- Add security-focused tests for risky paths.
+
+## Go + Sear Checklist
+- JWT validation paths enforce algorithm/method checks.
+- Root/basic auth and client JWT access boundaries are not mixed incorrectly.
+- Request bodies and path params are validated before use.
+- Shell/command execution paths avoid injection vectors.
+- Artifact upload/download paths prevent traversal and unauthorized access.
+- Secrets are never exposed in list endpoints or logs.
+- Persistent files use restrictive permissions.
+
+## Suggested Commands
+Use what is available in environment:
+
+- go test ./... -v -count=1
+- go test ./... -race -count=1
+- go vet ./...
+- govulncheck ./...
+- go list -m -u all
+
+If `govulncheck` is unavailable, report that and continue with code-level review plus `go vet`.
+
+## Evidence Rules
+For each finding include:
+- Severity.
+- Affected file and line reference.
+- Why it is risky and realistic abuse scenario.
+- Concrete fix recommendation.
+- Test/verification recommendation.
+
+## Recommended Model
+- **Best fit**: Reasoning model.
+- Adversarial reasoning for threat modeling, abuse scenario construction, and attack surface analysis.
+- Policy and principle recall for OWASP, CWE, and secure design patterns.
+- Structured risk ranking with exploitability and remediation rationale.
+
+## Non-Goals
+- Broad stylistic linting.
+- Re-architecting the system unless required to mitigate a critical issue.

--- a/.github/skills/test-driven-development/SKILL.md
+++ b/.github/skills/test-driven-development/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: test-driven-development
+description: "Use when writing unit tests, practicing TDD, or improving test coverage. Triggers: write tests, test-driven development, TDD, unit test, table tests, test coverage, test gaps, missing assertions, test refactor, behavior verification. Produces well-structured tests with clear arrange/act/assert form, coverage for happy paths and edge cases, and actionable guidance for test-first workflows."
+---
+
+# Test-Driven Development Skill
+
+## Goal
+Help developers write effective unit tests and apply TDD to produce correct, maintainable, and confidence-building test suites.
+
+## Scope
+This skill is for:
+- Writing unit tests for new and existing code.
+- Practicing red/green/refactor TDD cycles.
+- Identifying test gaps and missing assertions.
+- Structuring table-driven and subtests idiomatically.
+- Improving test quality, coverage, and readability.
+- Detecting tests that assert the wrong things or provide false confidence.
+
+## Output Contract
+Return results in this order:
+
+1. Test strategy summary (what to test and why).
+2. Test cases list (happy path, edge cases, failure paths).
+3. Implemented test code.
+4. Coverage impact notes.
+5. Follow-up test gaps remaining.
+
+## Workflow
+
+1. Understand the unit under test
+- Identify inputs, outputs, and observable side effects.
+- Detect dependencies that require mocking or faking.
+- Confirm what behavior is contractual versus implementation detail.
+
+2. Define test cases before writing code (TDD)
+- Write the failing test first when practicing TDD.
+- Name tests after behavior, not implementation.
+- Cover: happy path, boundary values, invalid inputs, and error paths.
+
+3. Write clean, structured tests
+- Use arrange/act/assert structure consistently.
+- Keep each test focused on one behavior.
+- Use table-driven tests for repeated logic with varying inputs.
+- Use subtests to group related cases with shared setup.
+
+4. Handle dependencies safely
+- Use interfaces and fakes over live dependencies.
+- Avoid test coupling to internal implementation details.
+- Prefer in-memory fakes over mocks where practical.
+
+5. Validate test quality
+- Confirm each assertion fails when the real behavior is wrong.
+- Check that test names describe failure context clearly.
+- Avoid logical assertions that can never fail.
+- Prefer specific assertions over broad catch-all checks.
+
+6. Measure and close coverage gaps
+- Identify untested paths with coverage tooling.
+- Prioritize covering critical paths and boundary conditions.
+- Do not chase 100% coverage at the expense of test value.
+
+## Quality Bar
+- Tests must fail before the implementation is correct and pass after.
+- Test names read as behavioral sentences.
+- No shared mutable state between test cases.
+- Tests are deterministic and do not depend on execution order.
+- Concurrency tests must be race-safe.
+
+## Go-Specific Defaults
+- Use the standard `testing` package.
+- Table-driven tests via `[]struct{ name, input, expected }` slices.
+- Subtests via `t.Run`.
+- Race checks: `go test ./... -race -count=1`.
+- Coverage profile: `go test ./... -coverprofile=cover.out; go tool cover -func=cover.out`.
+- Use `httptest` for HTTP handler tests.
+- Use interface fakes for stores, hubs, and external clients.
+
+## Recommended Model
+- **Best fit**: Coding model.
+- Code generation for idiomatic, compiling test code with correct arrange/act/assert structure.
+- Knowledge of Go testing patterns (table tests, subtests, `httptest`, fakes).
+- Coverage analysis reasoning to find meaningful gaps and prioritize test cases.
+
+## Non-Goals
+- Writing tests that replicate implementation details instead of behavior.
+- Achieving 100% coverage as a primary metric over test quality.
+- Using heavyweight mocking frameworks when simple fakes suffice.


### PR DESCRIPTION
This pull request introduces a new suite of reusable Copilot skills to the repository, designed to support various engineering tasks such as code interpretation, review, refactoring, architecture analysis, developer experience, documentation synchronization, and design compliance. Each skill is documented with its purpose, workflow, output contract, and quality standards, making them easy for developers and Copilot to use for targeted guidance and automation.

Addition of Copilot skills:

* Added `.github/skills/code-interpretation/SKILL.md` describing the code interpretation skill for understanding generated or unfamiliar code, including its workflow and output contract.
* Added `.github/skills/code-review/SKILL.md` detailing the code review skill, with severity-ranked findings, evidence rules, and Go-specific review checklist.
* Added `.github/skills/refactor/SKILL.md` documenting the refactor skill for behavior-preserving code restructuring, including safety rules and Go-specific checklist.
* Added `.github/skills/architecture-awareness/SKILL.md` outlining the architecture awareness skill for mapping project structure, runtime behavior, and safe feature extension.
* Added `.github/skills/developer-experience/SKILL.md` specifying the developer experience skill for workflow setup, CI/CD, devcontainer, and onboarding improvements.
* Added `.github/skills/documentation/SKILL.md` describing the documentation sync skill for keeping docs up-to-date with code changes, including impact matrix and verification checklist.
* Added `.github/skills/design-compliance/SKILL.md` detailing the design compliance skill for enforcing design principles, patterns, and maintainability standards.

Documentation updates:

* Updated `.github/copilot-instructions.md` to list and describe the available Copilot skills, their purposes, and triggers for use.

These changes provide a structured foundation for Copilot-driven automation and guidance, enabling consistent, high-quality engineering practices across the repository.