### PR TITLE
Update documentation: add playbook model and enhance README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sear helps infrastructure teams roll out and manage repeatable deployments acros
 | For operators | For integration | For contributors |
 | --- | --- | --- |
 | [Download releases](https://github.com/marko-stanojevic/sear/releases) | [API endpoints](docs/api-endpoints.md) | [Contributing guide](CONTRIBUTING.md) |
-| [Quick start](#quick-start) | [Playbook model](#playbook-model) | [Project docs](#documentation) |
+| [Quick start](#quick-start) | [Playbook model](docs/playbook-model.md) | [Project docs](docs/documentation.md) |
 
 ## Why teams choose sear
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,69 @@
+# Sear Project Documentation Index
+
+Welcome to the Sear documentation hub. This index provides easy access to all guides, references, and support resources for operators, integrators, and contributors.
+
+---
+
+## 📚 Guides & References
+
+- [API Endpoints](api-endpoints.md): HTTP and WebSocket API reference for sear-daemon.
+- [Playbook Model](playbook-model.md): Workflow structure, environment injection, secrets, and artifact usage.
+- [Example Playbook](../examples/playbook.yml): Sample deployment workflow.
+- [Daemon Configuration](../examples/config.yml): Daemon config example.
+- [Client Configuration](../examples/client.config.yml): Client config example.
+- [Secrets File](../examples/secrets.yml): Daemon secrets example.
+- [Contributing Guide](../CONTRIBUTING.md): How to contribute to Sear.
+
+---
+
+## 🚀 Onboarding & Quick Start
+
+- [Quick Start in README](../README.md#quick-start): Step-by-step setup for new users.
+- [Operator Guide](../README.md#platform-overview): Overview of Sear components and their roles.
+- [Dashboard UI](../README.md#quick-start): Access real-time status and deployment logs.
+
+---
+
+## ❓ Frequently Asked Questions (FAQ)
+
+**Q: How do I register a new client?**
+A: Set a matching `registration_secret` in both daemon and client configs, then run the client binary with its config.
+
+**Q: How are secrets managed?**
+A: Secrets are defined in `secrets.yml` and injected into playbooks using `${{ secrets.NAME }}` syntax.
+
+**Q: What happens if a client reboots during deployment?**
+A: Sear resumes from the last confirmed step after reboot, ensuring deterministic rollout.
+
+**Q: How are artifacts distributed?**
+A: Artifacts are uploaded to the daemon and referenced in playbooks; clients download them automatically during workflow execution.
+
+**Q: Where are deployment logs stored?**
+A: All logs are persisted in the daemon's logs directory for audit and troubleshooting.
+
+---
+
+## ⚙️ Technical Choices & Quality Practices
+
+- **Language:** Go (no CGo dependencies; portable and cross-compilable)
+- **Workflow Engine:** YAML-based, inspired by GitHub Actions for familiar syntax
+- **Authentication:** JWT for clients, HTTP Basic for root endpoints
+- **Persistence:** Durable state and logs for reboot-safe operation
+- **Testing:** Extensive unit and integration tests, race detection enabled
+- **Linting:** Static analysis via `go vet` and `golangci-lint`
+- **CI/CD:** Automated builds, tests, and releases with GitHub Actions
+- **Documentation:** Maintained as first-class artifacts, updated with every feature/refactor
+
+---
+
+## 🏆 Project Values
+
+- **Usability:** Clear onboarding, example configs, and dashboard UI for easy adoption
+- **Reliability:** Reboot-safe deployments, artifact distribution, and log persistence
+- **Security:** Secret injection, registration secrets, and audit logs
+- **Extensibility:** Modular design for custom workflows and integrations
+- **Support:** Responsive issue tracking and community engagement
+
+---
+
+For additional help, see the README or open an issue on GitHub. If you have suggestions for improvement, please contribute or contact the maintainers.

--- a/docs/playbook-model.md
+++ b/docs/playbook-model.md
@@ -1,0 +1,72 @@
+# Playbook Model
+
+This document describes the structure and features of Sear playbooks for deployment automation.
+
+## Overview
+
+A playbook defines a repeatable deployment workflow as a sequence of jobs and steps, with support for environment variables, secrets, artifact distribution, and reboot-safe execution.
+
+## Structure
+
+- **name**: Human-readable playbook name.
+- **env**: Playbook-level environment variables (available in all steps).
+- **jobs**: Ordered list of jobs, each with a name and steps.
+
+### Example
+
+```yaml
+name: "Production App Deployment"
+env:
+  APP_VERSION: "3.1.0"
+  DEPLOY_ENV:  "production"
+jobs:
+  - name: "os-prep"
+    steps:
+      - name: "Install dependencies"
+        shell: bash
+        run: |
+          apt-get update -qq
+          apt-get install -y nginx curl jq
+      - name: "Configure sysctl"
+        shell: bash
+        run: |
+          echo "vm.swappiness=10" >> /etc/sysctl.d/99-sear.conf
+      - name: "Reboot to apply kernel settings"
+        uses: reboot
+        with:
+          reason: "Apply sysctl and kernel parameters"
+  - name: "app-install"
+    steps:
+      - name: "Download application binary"
+        uses: download-artifact
+        with:
+          artifact: "myapp-v3.1.0"
+          path: /opt/myapp
+```
+
+## Features
+
+- **Ordered jobs and steps**: Jobs execute in the order listed; steps within each job are run sequentially.
+- **Environment injection**: Use `env` for variables available in all steps; step-level `env` can override.
+- **Secrets**: Inject secrets into steps using `${{ secrets.NAME }}` syntax.
+- **Artifact distribution**: Steps can use `download-artifact` to fetch files from the daemon.
+- **Reboot-safe execution**: If a reboot step is used, the client resumes from the next job after reboot.
+- **Timeouts**: Steps can specify `timeout-minutes` to limit execution time.
+
+## Step Types
+
+- **Shell steps**: Run shell commands (`shell: bash` or `shell: powershell`).
+- **Built-in actions**: Use `uses:` for built-in actions like `reboot` or `download-artifact`.
+
+## Best Practices
+
+- Use descriptive job and step names for clarity.
+- Group related steps into jobs for logical phases.
+- Use environment variables and secrets to avoid hardcoding sensitive values.
+- Use artifact distribution for binaries and config files.
+- Use reboot steps for kernel or OS changes that require restart.
+
+## References
+
+- [Example playbook](../examples/playbook.yml)
+- [API endpoints](api-endpoints.md)


### PR DESCRIPTION
This pull request introduces new documentation files and updates references in the `README.md` to improve discoverability and guidance for users, contributors, and integrators. The main focus is on providing a comprehensive documentation index and detailed playbook model, as well as ensuring all documentation links are consistent and accessible.

Documentation improvements:

* Added a new `docs/documentation.md` file that serves as a central index for guides, onboarding, FAQs, technical choices, and project values, making it easier for users to find relevant information.
* Introduced `docs/playbook-model.md`, which explains the structure, features, and best practices for Sear playbooks, including example YAML and references to related docs.

README link updates:

* Updated documentation links in the `README.md` to reference the new `docs/playbook-model.md` and `docs/documentation.md` files, ensuring that the quick start, playbook model, and project docs sections point to the correct resources.