### PR TITLE
Remove MacOS and Windows from CI/CD unit tests to save costs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
@@ -70,7 +67,6 @@ jobs:
         uses: ./.github/actions/go-test
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5
         with:
           files: coverage.out

--- a/.github/workflows/cleanup-releases.yml
+++ b/.github/workflows/cleanup-releases.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       contents: write # Needed to delete releases and tags
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Delete old releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request makes adjustments to the CI and cleanup workflows to simplify platform targeting and improve repository checkout handling. The main changes include running unit tests only on Ubuntu, removing unnecessary matrix logic, and ensuring the repository is checked out before cleanup steps.

CI workflow simplification:

* Changed the `test` job in `.github/workflows/ci.yml` to run only on `ubuntu-latest`, removing the matrix strategy for multiple OSes.
* Removed the conditional for uploading coverage to Codecov, since tests now only run on Ubuntu.

Cleanup workflow improvement:

* Added a step to check out the repository using `actions/checkout@v6` before deleting old releases in `.github/workflows/cleanup-releases.yml`.