### PR TITLE
Re-brand UI pages

### DIFF
--- a/internal/daemon/handlers/ui/artifacts.html
+++ b/internal/daemon/handlers/ui/artifacts.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Sear - Artifacts</title>
+  <title>Kompakt — Artifacts</title>
   <link rel="stylesheet" href="/ui/assets/style.css">
   <style>html,body{background:#0d1117;color:#e6edf3}</style>
 </head>
 <body>
 <header>
-  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Sear</h1> <span class="badge">DASHBOARD</span></div>
+  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Kompakt</h1> <span class="badge">DASHBOARD</span></div>
   <nav>
     <a href="/ui">Home</a>
     <a href="/ui/clients">Clients</a>
@@ -63,6 +63,7 @@
         <input id="artifact-clients" type="text" placeholder="client-uuid-1, client-uuid-2">
       </div>
     </div>
+    <div class="modal-err" id="upload-modal-err"></div>
     <div class="modal-actions">
         <button class="btn-muted" onclick="closeModal('modal-upload')">Cancel</button>
         <button class="btn-add" onclick="uploadArtifact()">Upload</button>
@@ -166,16 +167,6 @@ function render() {
     rows +
     '</div>';
 
-  // Toggle menus
-  root.querySelectorAll('.menu-btn').forEach(btn => {
-    btn.addEventListener('click', function(e) {
-      e.stopPropagation();
-      const menu = this.nextElementSibling;
-      const isOpen = menu.classList.contains('open');
-      document.querySelectorAll('.menu-dropdown.open').forEach(d => d.classList.remove('open'));
-      if (!isOpen) menu.classList.add('open');
-    });
-  });
   updateIcons();
 }
 
@@ -246,22 +237,17 @@ async function savePolicy() {
 }
 
 async function uploadArtifact() {
+  var errEl = document.getElementById('upload-modal-err');
   var fileInput = document.getElementById('artifact-file');
-  if (!fileInput.files.length) { alert('Please select a file'); return; }
+  if (!fileInput.files.length) { errEl.textContent = 'Please select a file'; return; }
   var file = fileInput.files[0];
   var name = document.getElementById('artifact-name').value.trim();
   var filename = file.name;
 
-  var btn = document.getElementById('btn-save');
-  btn.disabled = true;
-  btn.textContent = 'Uploading...';
-
   try {
-    var h = headersAuth();
     var policy = document.getElementById('artifact-policy').value;
     var clients = document.getElementById('artifact-clients').value.trim();
 
-    // Raw body upload as expected by HandleArtifacts
     var params = '?filename=' + encodeURIComponent(filename);
     if (name) params += '&name=' + encodeURIComponent(name);
     params += '&access_policy=' + encodeURIComponent(policy);
@@ -271,38 +257,32 @@ async function uploadArtifact() {
 
     var r = await fetch('/artifacts' + params, {
       method: 'POST',
-      headers: h,
+      headers: headersAuth(),
       body: file
     });
-    if (r.status === 401) { showLogin('Session expired - sign in again'); return; }
-    if (!r.ok) { alert('Upload failed: ' + r.status); return; }
+    if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
+    if (!r.ok) { errEl.textContent = 'Upload failed (' + r.status + ')'; return; }
     closeModal('modal-upload');
     load();
   } catch (e) {
-    alert('Upload error: ' + e);
-  } finally {
-    btn.disabled = false;
-    btn.textContent = 'Upload';
+    errEl.textContent = 'Network error: ' + e.message;
   }
 }
 
 async function removeArtifact(id) {
   if (!confirm('Delete artifact?')) return;
-  var r = await fetch('/artifacts/' + encodeURIComponent(id), {
-    method: 'DELETE',
-    headers: headersAuth()
-  });
-  if (r.status === 401) { showLogin('Session expired - sign in again'); return; }
-  if (!r.ok) { alert('Delete failed: ' + r.status); return; }
-  load();
-}
-
-// Click outside to close menus
-document.addEventListener('click', function(e) {
-  if (!e.target.classList.contains('menu-btn')) {
-    document.querySelectorAll('.menu-dropdown.open').forEach(d => d.classList.remove('open'));
+  try {
+    var r = await fetch('/artifacts/' + encodeURIComponent(id), {
+      method: 'DELETE',
+      headers: headersAuth()
+    });
+    if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
+    if (!r.ok) { document.getElementById('counts').textContent = 'Delete failed (' + r.status + ')'; return; }
+    load();
+  } catch(e) {
+    document.getElementById('counts').textContent = 'Network error';
   }
-});
+}
 
 document.getElementById('f-query').addEventListener('input', function() { render(); updateClearBtn(); });
 initLogin('/api/v1/status', load);

--- a/internal/daemon/handlers/ui/assets/layout.js
+++ b/internal/daemon/handlers/ui/assets/layout.js
@@ -27,7 +27,6 @@ function ensureLoginOverlay() {
       <button class="btn-login" onclick="window.doLogin()">Sign in</button>
     </div>
   `;
-  overlay.style.display = 'none'; // Ensure it's hidden during construction
   document.body.appendChild(overlay);
 }
 

--- a/internal/daemon/handlers/ui/deployments.html
+++ b/internal/daemon/handlers/ui/deployments.html
@@ -1,14 +1,15 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sear - Deployments</title>
+<title>Kompakt — Deployments</title>
   <link rel="stylesheet" href="/ui/assets/style.css">
   <style>html,body{background:#0d1117;color:#e6edf3}</style>
 </head>
 <body>
 <header>
-  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Sear</h1> <span class="badge">DASHBOARD</span></div>
+  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Kompakt</h1> <span class="badge">DASHBOARD</span></div>
   <nav>
     <a href="/ui">Home</a>
     <a href="/ui/clients">Clients</a>
@@ -94,33 +95,18 @@ function render(){
     rows+
   '</div>';
   updateIcons();
-  // Click outside to close menus
-  document.addEventListener('click', function(e) {
-    if (!e.target.classList.contains('menu-btn')) {
-      document.querySelectorAll('.menu-dropdown.open').forEach(d => d.classList.remove('open'));
-    }
-  });
-
-  // Toggle menus
-  root.querySelectorAll('.menu-btn').forEach(btn => {
-    btn.addEventListener('click', function(e) {
-      e.stopPropagation();
-      const menu = this.nextElementSibling;
-      const isOpen = menu.classList.contains('open');
-      document.querySelectorAll('.menu-dropdown.open').forEach(d => d.classList.remove('open'));
-      if (!isOpen) menu.classList.add('open');
-    });
-  });
 }
 
 async function removeDeployment(id) {
   if (!confirm('Remove deployment "' + id + '"?\nThis will remove it from state and delete its logs.')) return;
-  const auth = (typeof authHeader === 'function') ? authHeader() : null;
-  const h = {}; if (auth) h['Authorization'] = auth;
-  const r = await fetch('/api/v1/deployments/' + encodeURIComponent(id), { method: 'DELETE', headers: h });
-  if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
-  if (!r.ok) { alert('Delete failed: ' + r.status); return; }
-  load();
+  try {
+    const r = await fetch('/api/v1/deployments/' + encodeURIComponent(id), { method: 'DELETE', headers: headersAuth() });
+    if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
+    if (!r.ok) { document.getElementById('counts').textContent = 'Delete failed (' + r.status + ')'; return; }
+    load();
+  } catch(e) {
+    document.getElementById('counts').textContent = 'Network error';
+  }
 }
 
 async function openLogs(id){
@@ -164,13 +150,17 @@ async function openLogs(id){
 function closeLogs(){document.getElementById('logs-panel').style.display='none';}
 
 async function load(){
-  var r=await fetch('/api/v1/deployments',{headers:headersAuth()});
-  if(r.status===401){showLogin('');return;}
-  if(!r.ok){document.getElementById('root').innerHTML='<div class="empty">Failed to load deployments.</div>';return;}
-  deployments=await r.json()||[];
-  deployments.sort(function(a,b){return new Date(b.updated_at||0)-new Date(a.updated_at||0);});
-  render();
-  updateClearBtn();
+  try {
+    var r=await fetch('/api/v1/deployments',{headers:headersAuth()});
+    if(r.status===401){showLogin('');return;}
+    if(!r.ok){document.getElementById('root').innerHTML='<div class="empty">Failed to load deployments.</div>';return;}
+    deployments=await r.json()||[];
+    deployments.sort(function(a,b){return new Date(b.updated_at||0)-new Date(a.updated_at||0);});
+    render();
+    updateClearBtn();
+  } catch(e) {
+    document.getElementById('root').innerHTML='<div class="empty">Network error. Retrying&#x2026;</div>';
+  }
 }
 function updateClearBtn() {
   var q = document.getElementById('f-query').value;
@@ -178,8 +168,16 @@ function updateClearBtn() {
 }
 
 document.getElementById('f-query').addEventListener('input',function(){render();updateClearBtn();});
+
+var _autoRefreshTimer = null;
+function startAutoRefresh() { _autoRefreshTimer = setInterval(load, 10000); }
+function stopAutoRefresh() { clearInterval(_autoRefreshTimer); _autoRefreshTimer = null; }
+document.addEventListener('visibilitychange', function() {
+  if (document.hidden) { stopAutoRefresh(); } else { load(); startAutoRefresh(); }
+});
+
 initLogin('/api/v1/deployments', load);
-setInterval(load,10000);
+startAutoRefresh();
 </script>
 </body>
 </html>

--- a/internal/daemon/handlers/ui/index.html
+++ b/internal/daemon/handlers/ui/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sear — Dashboard</title>
+<title>Kompakt — Dashboard</title>
 <link rel="stylesheet" href="/ui/assets/style.css">
 <style>html,body{background:#0d1117;color:#e6edf3}</style>
 <style>
@@ -72,7 +72,7 @@
 <body>
 <header>
   <div class="header-brand">
-    <h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Sear</h1>
+    <h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Kompakt</h1>
     <span class="badge">DASHBOARD</span>
   </div>
   <nav id="main-nav">
@@ -83,8 +83,8 @@
 </header>
 <div class="container">
   <div class="welcome-section">
-    <h2>Welcome to Sear</h2>
-    <p>Simplified Execution and Artifact Repository. Manage your infrastructure with ease.</p>
+    <h2>Welcome to Kompakt</h2>
+    <p>Deployment automation for your infrastructure. Manage clients, playbooks, and deployments with ease.</p>
   </div>
 
   <div class="dashboard-grid">

--- a/internal/daemon/handlers/ui/playbooks.html
+++ b/internal/daemon/handlers/ui/playbooks.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sear - Playbooks</title>
+<title>Kompakt — Playbooks</title>
   <link rel="stylesheet" href="/ui/assets/style.css">
   <style>html,body{background:#0d1117;color:#e6edf3}</style>
 </head>
@@ -38,7 +39,7 @@
   </div>
 </div>
 <header>
-  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Sear</h1> <span class="badge">DASHBOARD</span></div>
+  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Kompakt</h1> <span class="badge">DASHBOARD</span></div>
     <nav>
       <a href="/ui">Home</a>
       <a href="/ui/clients">Clients</a>
@@ -135,10 +136,14 @@ async function savePlaybook(){
 async function removePlaybook(i){
   var pb=playbooks[i];
   if(!confirm('Delete playbook "'+(pb.name||pb.id)+'"?'))return;
-  var r=await fetch('/api/v1/playbooks/'+encodeURIComponent(pb.id),{method:'DELETE',headers:headersAuth()});
-  if(r.status===401){showLogin('Session expired - sign in again');return;}
-  if(!r.ok){alert('Delete failed: '+r.status);return;}
-  load();
+  try {
+    var r=await fetch('/api/v1/playbooks/'+encodeURIComponent(pb.id),{method:'DELETE',headers:headersAuth()});
+    if(r.status===401){showLogin('Session expired — sign in again');return;}
+    if(!r.ok){document.getElementById('counts').textContent='Delete failed ('+r.status+')';return;}
+    load();
+  } catch(e) {
+    document.getElementById('counts').textContent='Network error';
+  }
 }
 
 function openAssign(i){
@@ -222,14 +227,20 @@ function render(){
 }
 
 async function load(){
-  var p=await fetch('/api/v1/playbooks',{headers:headersAuth()});
-  if(p.status===401){showLogin('');return;}
-  if(!p.ok){document.getElementById('root').innerHTML='<div class="empty">Failed to load playbooks.</div>';return;}
-  var c=await fetch('/api/v1/clients',{headers:headersAuth()});
-  clients=c.ok?await c.json():[];
-  playbooks=await p.json()||[];
-  render();
-  updateClearBtn();
+  try {
+    const [p, c] = await Promise.all([
+      fetch('/api/v1/playbooks', {headers:headersAuth()}),
+      fetch('/api/v1/clients', {headers:headersAuth()})
+    ]);
+    if(p.status===401){showLogin('');return;}
+    if(!p.ok){document.getElementById('root').innerHTML='<div class="empty">Failed to load playbooks.</div>';return;}
+    clients = c.ok ? await c.json() : [];
+    playbooks = await p.json() || [];
+    render();
+    updateClearBtn();
+  } catch(e) {
+    document.getElementById('root').innerHTML='<div class="empty">Network error. Retrying&#x2026;</div>';
+  }
 }
 function updateClearBtn() {
   var q = document.getElementById('f-query').value;

--- a/internal/daemon/handlers/ui/secrets.html
+++ b/internal/daemon/handlers/ui/secrets.html
@@ -1,8 +1,9 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sear — Secrets</title>
+<title>Kompakt — Secrets</title>
   <link rel="stylesheet" href="/ui/assets/style.css">
   <style>html,body{background:#0d1117;color:#e6edf3}</style>
 </head>
@@ -25,7 +26,7 @@
   </div>
 </div>
 <header>
-  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Sear</h1> <span class="badge">DASHBOARD</span></div>
+  <div class="header-brand"><h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Kompakt</h1> <span class="badge">DASHBOARD</span></div>
     <nav>
       <a href="/ui">Home</a>
       <a href="/ui/clients">Clients</a>
@@ -90,10 +91,13 @@ async function openEdit(i){
   modalVisible=false;
   document.getElementById('modal-err').textContent='';
   document.getElementById('modal-bg').classList.add('show');
-  var auth=authHeader();
-  var h={};if(auth)h['Authorization']=auth;
-  var r=await fetch('/api/v1/secrets/'+encodeURIComponent(name),{headers:h});
-  if(r.ok){var d=await r.json();document.getElementById('modal-value').value=d.value||'';}
+  try {
+    var r=await fetch('/api/v1/secrets/'+encodeURIComponent(name),{headers:headersAuth()});
+    if(r.status===401){closeModal();showLogin('Session expired — sign in again');return;}
+    if(r.ok){var d=await r.json();document.getElementById('modal-value').value=d.value||'';}
+  } catch(e) {
+    document.getElementById('modal-err').textContent='Network error loading secret';
+  }
   setTimeout(function(){document.getElementById('modal-value').focus();},50);
 }
 function closeModal(){
@@ -105,23 +109,27 @@ async function saveSecret(){
   var value=document.getElementById('modal-value').value;
   var errEl=document.getElementById('modal-err');
   if(!name){errEl.textContent='Name is required';return;}
-  var auth=authHeader();
-  var h={'Content-Type':'application/json'};if(auth)h['Authorization']=auth;
-  var r=await fetch('/api/v1/secrets/'+encodeURIComponent(name),{method:'PUT',headers:h,body:JSON.stringify({value:value})});
-  if(r.status===401){closeModal();showLogin('Session expired — sign in again');return;}
-  if(!r.ok){errEl.textContent='Save failed ('+r.status+')';return;}
-  closeModal();
-  load();
+  try {
+    var r=await fetch('/api/v1/secrets/'+encodeURIComponent(name),{method:'PUT',headers:headersJSON(),body:JSON.stringify({value:value})});
+    if(r.status===401){closeModal();showLogin('Session expired — sign in again');return;}
+    if(!r.ok){errEl.textContent='Save failed ('+r.status+')';return;}
+    closeModal();
+    load();
+  } catch(e) {
+    errEl.textContent='Network error';
+  }
 }
 async function deleteSecret(i){
   var name=names[i];
   if(!confirm('Delete secret "'+name+'"?\nThis cannot be undone.'))return;
-  var auth=authHeader();
-  var h={};if(auth)h['Authorization']=auth;
-  var r=await fetch('/api/v1/secrets/'+encodeURIComponent(name),{method:'DELETE',headers:h});
-  if(r.status===401){showLogin('Session expired — sign in again');return;}
-  if(!r.ok){alert('Delete failed: '+r.status);return;}
-  load();
+  try {
+    var r=await fetch('/api/v1/secrets/'+encodeURIComponent(name),{method:'DELETE',headers:headersAuth()});
+    if(r.status===401){showLogin('Session expired — sign in again');return;}
+    if(!r.ok){document.getElementById('counts').textContent='Delete failed ('+r.status+')';return;}
+    load();
+  } catch(e) {
+    document.getElementById('counts').textContent='Network error';
+  }
 }
 
 var revealed={};
@@ -137,16 +145,18 @@ async function toggleReveal(i) {
     updateIcons();
     return;
   }
-  var auth = authHeader();
-  var h = {}; if (auth) h['Authorization'] = auth;
-  var r = await fetch('/api/v1/secrets/' + encodeURIComponent(name), { headers: h });
-  if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
-  if (!r.ok) { alert('Failed to fetch secret value'); return; }
-  var d = await r.json();
-  revealed[name] = d.value || '';
-  el.textContent = d.value || '(empty)';
-  el.className = 'sval revealed';
-  btn.innerHTML = '<span class="m-icon">👁️</span> Hide';
+  try {
+    var r = await fetch('/api/v1/secrets/' + encodeURIComponent(name), { headers: headersAuth() });
+    if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
+    if (!r.ok) { document.getElementById('counts').textContent = 'Failed to fetch secret'; return; }
+    var d = await r.json();
+    revealed[name] = d.value || '';
+    el.textContent = d.value || '(empty)';
+    el.className = 'sval revealed';
+    btn.innerHTML = '<span class="m-icon">👁️</span> Hide';
+  } catch(e) {
+    document.getElementById('counts').textContent = 'Network error';
+  }
 }
 
 function filteredNames() {
@@ -201,14 +211,17 @@ function render(){
   updateIcons();
 }
 async function load(){
-  var auth=authHeader();
-  var h={};if(auth)h['Authorization']=auth;
-  var r=await fetch('/api/v1/secrets',{headers:h});
-  if(r.status===401){showLogin('');return;}
-  revealed={};
-  names=await r.json()||[];
-  render();
-  updateClearBtn();
+  try {
+    var r=await fetch('/api/v1/secrets',{headers:headersAuth()});
+    if(r.status===401){showLogin('');return;}
+    if(!r.ok){document.getElementById('root').innerHTML='<div class="empty">Failed to load secrets.</div>';return;}
+    revealed={};
+    names=await r.json()||[];
+    render();
+    updateClearBtn();
+  } catch(e) {
+    document.getElementById('root').innerHTML='<div class="empty">Network error. Retrying&#x2026;</div>';
+  }
 }
 function updateClearBtn() {
   var q = document.getElementById('f-query').value;

--- a/internal/daemon/handlers/ui/status.html
+++ b/internal/daemon/handlers/ui/status.html
@@ -1,15 +1,16 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Sear — Deployment Status</title>
+<title>Kompakt — Clients</title>
   <link rel="stylesheet" href="/ui/assets/style.css">
   <style>html,body{background:#0d1117;color:#e6edf3}</style>
 </head>
 <body>
 <header>
 	<div class="header-brand">
-		<h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Sear</h1>
+		<h1><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#f78166" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:text-bottom;margin-right:4px"><path d="M13 2 L3 14 h9 l-1 8 10-12 h-9 l1-8z"></path></svg> Kompakt</h1>
 		<span class="badge">DASHBOARD</span>
 	</div>
 	<nav>
@@ -41,13 +42,14 @@
 <script>
 async function removeClient(id, hostname) {
   if (!confirm('Remove client "' + hostname + '"?\nThis cannot be undone.')) return;
-  const creds = sessionStorage.getItem('kompakt_creds');
-  const headers = {'Content-Type':'application/json'};
-  if (creds) headers['Authorization'] = 'Basic ' + creds;
-	const r = await fetch('/api/v1/clients/' + encodeURIComponent(id), {method:'DELETE', headers});
-  if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
-  if (!r.ok) { alert('Failed to remove client: ' + r.status); return; }
-  load();
+  try {
+    const r = await fetch('/api/v1/clients/' + encodeURIComponent(id), {method:'DELETE', headers: headersAuth()});
+    if (r.status === 401) { showLogin('Session expired — sign in again'); return; }
+    if (!r.ok) { document.getElementById('counts').textContent = 'Remove failed (' + r.status + ')'; return; }
+    load();
+  } catch (e) {
+    document.getElementById('counts').textContent = 'Network error';
+  }
 }
 let latestClients = [];
 let latestDeps = {};
@@ -133,28 +135,37 @@ function clearFilters() {
 }
 
 async function load() {
-	const auth = (typeof authHeader === 'function') ? authHeader() : null;
-	const headers = auth ? { 'Authorization': auth } : {};
-	const r = await fetch('/api/v1/status', { headers });
-  if (r.status === 401) {
-    const root = document.getElementById('root');
-    root.innerHTML = '<div class="empty">Unauthorized. Reload the page to sign in.</div>';
-    return;
-  }
-  const d = await r.json();
-  latestDeps = {};
-  (d.deployments||[]).forEach(dep => { latestDeps[dep.client_id] = dep; });
-  latestClients = d.clients || [];
-  render();
-  updateClearBtn();
+	try {
+		const r = await fetch('/api/v1/status', { headers: headersAuth() });
+		if (r.status === 401) { showLogin(''); return; }
+		if (!r.ok) { document.getElementById('root').innerHTML = '<div class="empty">Failed to load.</div>'; return; }
+		const d = await r.json();
+		latestDeps = {};
+		(d.deployments||[]).forEach(dep => { latestDeps[dep.client_id] = dep; });
+		latestClients = d.clients || [];
+		render();
+		updateClearBtn();
+	} catch (e) {
+		document.getElementById('root').innerHTML = '<div class="empty">Network error. Retrying&#x2026;</div>';
+	}
 }
+
 function updateClearBtn() {
 	const q = document.getElementById('f-query').value;
 	document.getElementById('f-clear').classList.toggle('show', !!q);
 }
+
 document.getElementById('f-query').addEventListener('input', () => { render(); updateClearBtn(); });
+
+var _autoRefreshTimer = null;
+function startAutoRefresh() { _autoRefreshTimer = setInterval(load, 10000); }
+function stopAutoRefresh() { clearInterval(_autoRefreshTimer); _autoRefreshTimer = null; }
+document.addEventListener('visibilitychange', function() {
+  if (document.hidden) { stopAutoRefresh(); } else { load(); startAutoRefresh(); }
+});
+
 initLogin('/api/v1/status', load);
-setInterval(load, 10000);
+startAutoRefresh();
 </script>
 </body>
 </html>

--- a/internal/daemon/handlers/ui_assets.go
+++ b/internal/daemon/handlers/ui_assets.go
@@ -25,6 +25,9 @@ func ServeUIAsset(w http.ResponseWriter, r *http.Request) {
 	} else if len(importPath) > 4 && importPath[len(importPath)-4:] == ".css" {
 		w.Header().Set("Content-Type", "text/css; charset=utf-8")
 	}
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
 
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)

--- a/internal/daemon/service/manager.go
+++ b/internal/daemon/service/manager.go
@@ -89,13 +89,18 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
 		// Start new deployment
 		deploymentID = uuid.New().String()
 		newDep := &common.DeploymentState{
-			ID:              deploymentID,
-			ClientID:        clientID,
-			PlaybookID:      client.PlaybookID,
+			ID:           deploymentID,
+			ClientID:     clientID,
+			Hostname:     client.Hostname,
+			PlaybookID:   client.PlaybookID,
+			PlaybookName: pb.Name,
 			Status:          common.DeploymentStatusRunning,
 			ResumeStepIndex: 0,
 			StartedAt:       time.Now(),
 			UpdatedAt:       time.Now(),
+		}
+		if pb.Playbook != nil && pb.Playbook.Name != "" {
+			newDep.PlaybookName = pb.Playbook.Name
 		}
 		if err := m.Store.SaveDeployment(newDep); err != nil {
 			slog.Error("failed to save new deployment", "deployment_id", deploymentID, "client_id", clientID, "err", err)


### PR DESCRIPTION
This pull request makes several improvements to the UI for reliability and user experience, and also rebrands the application from "Sear" to "Kompakt" across all pages. The most important changes include enhanced error handling in API calls, improved feedback to users during operations, and the removal of menu toggle code. Additionally, the branding and welcome text have been updated to reflect the new application name and purpose.

**Rebranding and UI updates:**

* Changed all page titles, header branding, and welcome text from "Sear" to "Kompakt" in `artifacts.html`, `deployments.html`, `playbooks.html`, `secrets.html`, and `index.html`. The welcome section now describes deployment automation instead of artifact repository. [[1]](diffhunk://#diff-7a273291a89ea59738136663f4211e16ce0ebf7aea6497a5ffbacac02e2780acL6-R12) [[2]](diffhunk://#diff-fcd3dd520689cd17e449a3cd211b627676a278768b99526485e5052ac76de523R1-R12) [[3]](diffhunk://#diff-97d4b33c0110fab944ea6ed17fc5330989d12a654d0c96108f967578c7a1e434R1-R6) [[4]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02R1-R6) [[5]](diffhunk://#diff-2c39623196215d34a4bfec09926f24a01e3adda311fc80f7880fa117c71de186L6-R6) [[6]](diffhunk://#diff-2c39623196215d34a4bfec09926f24a01e3adda311fc80f7880fa117c71de186L75-R75) [[7]](diffhunk://#diff-2c39623196215d34a4bfec09926f24a01e3adda311fc80f7880fa117c71de186L86-R87) [[8]](diffhunk://#diff-97d4b33c0110fab944ea6ed17fc5330989d12a654d0c96108f967578c7a1e434L41-R42) [[9]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L28-R29)

**Error handling and user feedback improvements:**

* Replaced alert popups with inline error messages for artifact uploads, deletions, and secret operations, providing clearer feedback to users. Added dedicated error display elements to modals. [[1]](diffhunk://#diff-7a273291a89ea59738136663f4211e16ce0ebf7aea6497a5ffbacac02e2780acR66) [[2]](diffhunk://#diff-7a273291a89ea59738136663f4211e16ce0ebf7aea6497a5ffbacac02e2780acR240-L264) [[3]](diffhunk://#diff-7a273291a89ea59738136663f4211e16ce0ebf7aea6497a5ffbacac02e2780acL274-L305) [[4]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L93-R100) [[5]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L108-R132) [[6]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L140-R159) [[7]](diffhunk://#diff-97d4b33c0110fab944ea6ed17fc5330989d12a654d0c96108f967578c7a1e434R139-R146)
* Wrapped API calls in try/catch blocks for artifact, deployment, playbook, and secret actions, displaying network errors in the UI instead of silent failures or alerts. [[1]](diffhunk://#diff-7a273291a89ea59738136663f4211e16ce0ebf7aea6497a5ffbacac02e2780acL274-L305) [[2]](diffhunk://#diff-fcd3dd520689cd17e449a3cd211b627676a278768b99526485e5052ac76de523L97-R109) [[3]](diffhunk://#diff-fcd3dd520689cd17e449a3cd211b627676a278768b99526485e5052ac76de523R153-R180) [[4]](diffhunk://#diff-97d4b33c0110fab944ea6ed17fc5330989d12a654d0c96108f967578c7a1e434R139-R146) [[5]](diffhunk://#diff-97d4b33c0110fab944ea6ed17fc5330989d12a654d0c96108f967578c7a1e434L225-R243) [[6]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L93-R100) [[7]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L108-R132) [[8]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L140-R159)

**Code and UX simplification:**

* Removed menu toggle and click-outside-to-close logic from `artifacts.html` and `deployments.html`, simplifying the codebase. [[1]](diffhunk://#diff-7a273291a89ea59738136663f4211e16ce0ebf7aea6497a5ffbacac02e2780acL169-L178) [[2]](diffhunk://#diff-fcd3dd520689cd17e449a3cd211b627676a278768b99526485e5052ac76de523L97-R109)
* Improved auto-refresh logic for deployments by using visibility events and a named timer, reducing unnecessary refreshes when the page is hidden.

**Other minor improvements:**

* Updated error messages for session expiration to use an em dash for consistency. [[1]](diffhunk://#diff-7a273291a89ea59738136663f4211e16ce0ebf7aea6497a5ffbacac02e2780acL274-L305) [[2]](diffhunk://#diff-97d4b33c0110fab944ea6ed17fc5330989d12a654d0c96108f967578c7a1e434R139-R146) [[3]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L93-R100) [[4]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L108-R132) [[5]](diffhunk://#diff-c9041e8d23bcc993d9e3967787af6257d28850cda15c1ba431de86092fea6b02L140-R159)
* Removed unnecessary code that hid the login overlay during construction.