### PR TITLE
Refactor Go release workflow to create and push release tags within the action

### DIFF
--- a/.github/actions/go-release/action.yml
+++ b/.github/actions/go-release/action.yml
@@ -13,6 +13,9 @@ outputs:
   tag:
     description: Resolved release tag prefixed with v
     value: v${{ steps.version.outputs.majorMinorPatch }}
+  tag-created:
+    description: Whether the git tag was created in this run
+    value: ${{ steps.tag.outputs.created }}
 
 runs:
   using: composite
@@ -34,6 +37,24 @@ runs:
       with:
         useConfigFile: true
         configFilePath: gitversion.yml
+
+    - name: Create and push release tag
+      id: tag
+      shell: bash
+      env:
+        TAG: v${{ steps.version.outputs.majorMinorPatch }}
+      run: |
+        set -euo pipefail
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        if git rev-parse "$TAG" >/dev/null 2>&1; then
+          echo "Tag $TAG already exists."
+          echo "created=false" >> "$GITHUB_OUTPUT"
+        else
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,25 +23,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create and push release tag
-        id: tag
-        shell: bash
-        env:
-          TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists."
-            echo "created=false" >> "$GITHUB_OUTPUT"
-          else
-            git tag -a "$TAG" -m "Release $TAG"
-            git push origin "$TAG"
-            echo "created=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Check if GitHub release exists
         id: release-check
         shell: bash
@@ -119,7 +100,7 @@ jobs:
         shell: bash
         env:
           TAG: ${{ steps.release.outputs.tag }}
-          TAG_CREATED: ${{ steps.tag.outputs.created }}
+          TAG_CREATED: ${{ steps.release.outputs.tag-created }}
           RELEASE_EXISTS: ${{ steps.release-check.outputs.exists }}
           PREVIOUS_TAG: ${{ steps.notes.outputs.previous_tag }}
         run: |


### PR DESCRIPTION
This pull request refactors the release workflow to move the logic for creating and pushing git tags from the workflow file (`release.yml`) into the reusable action (`go-release`). This centralizes tag creation, simplifies the workflow, and ensures outputs are properly propagated.

**Refactoring and centralization of tag creation logic:**

* Moved the tag creation and push logic from the `release.yml` workflow file into the `.github/actions/go-release/action.yml` composite action, making the process reusable and easier to maintain. [[1]](diffhunk://#diff-8604b2897b402112c2955338cad335678c1ef8255afb9fd3dc7113d7f97665b0R41-R58) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L26-L44)

**Improvements to action outputs and workflow integration:**

* Added a new output `tag-created` to the `go-release` action to indicate whether the git tag was created during the run.
* Updated the workflow to use the new `tag-created` output from the `go-release` action, ensuring downstream steps receive accurate information about tag creation.