### PR TITLE
Enhance Codecov action configuration with additional options and remove redundant environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,12 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
           verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration for uploading coverage reports to Codecov. The change moves the `CODECOV_TOKEN` from the `env` section to the `with` section, aligning with the recommended usage for the Codecov GitHub Action.

* CI workflow update:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR72-L78): Passes `CODECOV_TOKEN` as a `with` parameter instead of an environment variable when uploading coverage to Codecov.