### PR TITLE
Add tests for handling corrupted YAML and missing files in daemon config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(grep -n \"^func\\\\|^type\\\\|^const\" /c/git/kompakt/internal/daemon/service/*.go)"
+      "Bash(grep -n \"^func\\\\|^type\\\\|^const\" /c/git/kompakt/internal/daemon/service/*.go)",
+      "Bash(wc -l /c/git/kompakt/internal/daemon/handlers/*.go)"
     ]
   }
 }

--- a/internal/common/config_test.go
+++ b/internal/common/config_test.go
@@ -207,6 +207,90 @@ func TestLoadConfigMissing(t *testing.T) {
 	}
 }
 
+// ── Negative path: corrupted / missing YAML ───────────────────────────────────
+
+func TestLoadDaemonConfig_CorruptedYAML(t *testing.T) {
+	path := writeTempFile(t, "config.yml", "listen_addr: [unclosed")
+	_, err := common.LoadDaemonConfig(path)
+	if err == nil {
+		t.Error("expected error for corrupted YAML, got nil")
+	}
+}
+
+func TestLoadDaemonSecrets_MissingFile(t *testing.T) {
+	_, err := common.LoadDaemonSecrets("/nonexistent/path/secrets.yml")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestLoadDaemonSecrets_CorruptedYAML(t *testing.T) {
+	path := writeTempFile(t, "secrets.yml", "root_password: [unclosed")
+	_, err := common.LoadDaemonSecrets(path)
+	if err == nil {
+		t.Error("expected error for corrupted YAML, got nil")
+	}
+}
+
+func TestLoadClientConfig_MissingFile(t *testing.T) {
+	_, err := common.LoadClientConfig("/nonexistent/path/client.yml")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestLoadClientConfig_CorruptedYAML(t *testing.T) {
+	path := writeTempFile(t, "client.yml", "server_url: [unclosed")
+	_, err := common.LoadClientConfig(path)
+	if err == nil {
+		t.Error("expected error for corrupted YAML, got nil")
+	}
+}
+
+func TestLoadClientConfig_MissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "missing server_url",
+			content: "registration_secret: abc\n",
+		},
+		{
+			name:    "missing registration_secret",
+			content: "server_url: http://kompakt:8080\n",
+		},
+		{
+			name:    "invalid platform",
+			content: "server_url: http://kompakt:8080\nregistration_secret: abc\nplatform: foobar\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTempFile(t, "client.yml", tt.content)
+			_, err := common.LoadClientConfig(path)
+			if err == nil {
+				t.Errorf("expected validation error for %q, got nil", tt.name)
+			}
+		})
+	}
+}
+
+func TestLoadPlaybook_MissingFile(t *testing.T) {
+	_, err := common.LoadPlaybook("/nonexistent/path/playbook.yml")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestLoadPlaybook_CorruptedYAML(t *testing.T) {
+	path := writeTempFile(t, "playbook.yml", "name: [unclosed")
+	_, err := common.LoadPlaybook(path)
+	if err == nil {
+		t.Error("expected error for corrupted YAML, got nil")
+	}
+}
+
 func writeTempFile(t *testing.T, name, content string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/daemon/handlers/auth_table_test.go
+++ b/internal/daemon/handlers/auth_table_test.go
@@ -1,0 +1,276 @@
+package handlers_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func expiredToken(t *testing.T, secret []byte, subject string) string {
+	t.Helper()
+	claims := jwt.RegisteredClaims{
+		Subject:   subject,
+		IssuedAt:  jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Hour)),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString(secret)
+	if err != nil {
+		t.Fatalf("sign expired token: %v", err)
+	}
+	return s
+}
+
+func wrongSigToken(t *testing.T, subject string) string {
+	t.Helper()
+	claims := jwt.RegisteredClaims{Subject: subject}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString([]byte("completely-different-secret"))
+	if err != nil {
+		t.Fatalf("sign wrong-sig token: %v", err)
+	}
+	return s
+}
+
+// ── RequireClientAuth ─────────────────────────────────────────────────────────
+
+func TestRequireClientAuth_TokenVariants(t *testing.T) {
+	env := newTestEnv(t)
+	secret := []byte("test-secret-key-32-bytes-padding!")
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name      string
+		buildReq  func() *http.Request
+		wantCode  int
+	}{
+		{
+			name: "no token at all",
+			buildReq: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "malformed bearer — not a JWT",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+				r.Header.Set("Authorization", "Bearer not.a.valid.jwt")
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "wrong signature",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+				r.Header.Set("Authorization", "Bearer "+wrongSigToken(t, "some-client"))
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "expired token",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+				r.Header.Set("Authorization", "Bearer "+expiredToken(t, secret, "some-client"))
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "empty bearer value",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+				r.Header.Set("Authorization", "Bearer ")
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "empty query token",
+			buildReq: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/api/v1/ws?token=", nil)
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			env.RequireClientAuth(okHandler).ServeHTTP(rr, tt.buildReq())
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d; want %d", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+// ── RequireRootAuth ───────────────────────────────────────────────────────────
+
+func TestRequireRootAuth_Variants(t *testing.T) {
+	env := newTestEnv(t)
+	secret := []byte("test-secret-key-32-bytes-padding!")
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Obtain a valid UI token via the login endpoint.
+	loginRR := postJSON(t, env.HandleUILogin, "/api/v1/ui/login", map[string]string{"password": "admin123"}, "")
+	if loginRR.Code != http.StatusOK {
+		t.Fatalf("HandleUILogin setup: status=%d body=%s", loginRR.Code, loginRR.Body.String())
+	}
+	uiToken := decode[map[string]string](t, loginRR)["token"]
+
+	// Obtain a valid agent token by registering a client.
+	_, agentToken := registerClient(t, env, "SN-ROOT-VARIANTS", "root-variants-client")
+
+	tests := []struct {
+		name     string
+		buildReq func() *http.Request
+		wantCode int
+	}{
+		{
+			name: "correct basic auth",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/status", nil)
+				r.SetBasicAuth("root", "admin123")
+				return r
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "wrong password",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/status", nil)
+				r.SetBasicAuth("root", "wrongpassword")
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "wrong username",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/status", nil)
+				r.SetBasicAuth("admin", "admin123")
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "no auth",
+			buildReq: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/status", nil)
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "valid UI JWT accepted",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/status", nil)
+				r.Header.Set("Authorization", "Bearer "+uiToken)
+				return r
+			},
+			wantCode: http.StatusOK,
+		},
+		{
+			name: "agent JWT rejected — no ui audience",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/status", nil)
+				r.Header.Set("Authorization", "Bearer "+agentToken)
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "expired token rejected",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/status", nil)
+				r.Header.Set("Authorization", "Bearer "+expiredToken(t, secret, "root"))
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name: "wrong signature rejected",
+			buildReq: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/status", nil)
+				r.Header.Set("Authorization", "Bearer "+wrongSigToken(t, "root"))
+				return r
+			},
+			wantCode: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			env.RequireRootAuth(okHandler).ServeHTTP(rr, tt.buildReq())
+			if rr.Code != tt.wantCode {
+				t.Errorf("status = %d; want %d", rr.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+// ── HandleUILogin ─────────────────────────────────────────────────────────────
+
+func TestHandleUILogin(t *testing.T) {
+	t.Run("correct password returns token", func(t *testing.T) {
+		env := newTestEnv(t)
+		rr := postJSON(t, env.HandleUILogin, "/api/v1/ui/login", map[string]string{"password": "admin123"}, "")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d; want 200 (body: %s)", rr.Code, rr.Body.String())
+		}
+		resp := decode[map[string]string](t, rr)
+		if resp["token"] == "" {
+			t.Error("expected non-empty token in response")
+		}
+	})
+
+	t.Run("wrong password rejected", func(t *testing.T) {
+		env := newTestEnv(t)
+		rr := postJSON(t, env.HandleUILogin, "/api/v1/ui/login", map[string]string{"password": "wrong"}, "")
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d; want 401", rr.Code)
+		}
+	})
+
+	t.Run("GET not allowed", func(t *testing.T) {
+		env := newTestEnv(t)
+		rr := getRequest(t, env.HandleUILogin, "/api/v1/ui/login", "")
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status = %d; want 405", rr.Code)
+		}
+	})
+
+	t.Run("invalid JSON body rejected", func(t *testing.T) {
+		env := newTestEnv(t)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/ui/login", bytes.NewBufferString("{"))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		env.HandleUILogin(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("status = %d; want 400", rr.Code)
+		}
+	})
+
+	t.Run("empty password rejected", func(t *testing.T) {
+		env := newTestEnv(t)
+		rr := postJSON(t, env.HandleUILogin, "/api/v1/ui/login", map[string]string{"password": ""}, "")
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d; want 401", rr.Code)
+		}
+	})
+}

--- a/internal/daemon/handlers/connect_internal_test.go
+++ b/internal/daemon/handlers/connect_internal_test.go
@@ -119,6 +119,20 @@ func TestHandleWSMessage_LogAndLifecycleUpdates(t *testing.T) {
 	}
 }
 
+func TestHandleWSMessage_UnknownType(t *testing.T) {
+	e := newConnectTestEnv(t)
+	saveClient(t, e, "c-unknown")
+	saveDeployment(t, e, "dep-unknown", "c-unknown", common.DeploymentStatusRunning)
+
+	before, _ := e.Store.GetDeployment("dep-unknown")
+	sendWS(t, e, "c-unknown", "totally_unknown_type_xyz", nil)
+	after, _ := e.Store.GetDeployment("dep-unknown")
+
+	if before.Status != after.Status || before.ResumeStepIndex != after.ResumeStepIndex {
+		t.Error("unknown message type should not mutate deployment state")
+	}
+}
+
 func TestHandleWSMessage_DeployFailedAndInvalidMessages(t *testing.T) {
 	e := newConnectTestEnv(t)
 	saveClient(t, e, "c2")

--- a/internal/daemon/handlers/env_internal_test.go
+++ b/internal/daemon/handlers/env_internal_test.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/marko-stanojevic/kompakt/internal/common"
+)
+
+// makeTestConn builds a WSConn suitable for unit tests: the ws field is nil
+// because Hub.Send and Hub.IsConnected never touch it.
+func makeTestConn(clientID string, bufSize int) *WSConn {
+	return &WSConn{
+		clientID: clientID,
+		send:     make(chan []byte, bufSize),
+		done:     make(chan struct{}),
+	}
+}
+
+// ── Hub ───────────────────────────────────────────────────────────────────────
+
+func TestHub_IsConnectedAndSend(t *testing.T) {
+	h := NewHub()
+
+	if h.IsConnected("c1") {
+		t.Fatal("IsConnected should return false before registration")
+	}
+
+	conn := makeTestConn("c1", 64)
+	h.mu.Lock()
+	h.conns["c1"] = conn
+	h.mu.Unlock()
+
+	if !h.IsConnected("c1") {
+		t.Fatal("IsConnected should return true after conn is added")
+	}
+
+	if !h.Send("c1", common.WSMessage{Type: common.WSMsgLog}) {
+		t.Fatal("Send should return true for connected client")
+	}
+
+	select {
+	case raw := <-conn.send:
+		var msg common.WSMessage
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			t.Fatalf("unmarshal sent message: %v", err)
+		}
+		if msg.Type != common.WSMsgLog {
+			t.Errorf("msg.Type = %q; want %q", msg.Type, common.WSMsgLog)
+		}
+	default:
+		t.Fatal("no message received in send channel")
+	}
+
+	h.unregister("c1")
+	if h.IsConnected("c1") {
+		t.Fatal("IsConnected should return false after unregister")
+	}
+}
+
+func TestHub_Send_NotConnected(t *testing.T) {
+	h := NewHub()
+	if h.Send("ghost", common.WSMessage{Type: common.WSMsgLog}) {
+		t.Error("Send should return false for unconnected client")
+	}
+}
+
+func TestHub_Send_QueueFull(t *testing.T) {
+	h := NewHub()
+	conn := makeTestConn("c2", 1)
+	h.mu.Lock()
+	h.conns["c2"] = conn
+	h.mu.Unlock()
+
+	if !h.Send("c2", common.WSMessage{Type: common.WSMsgLog}) {
+		t.Fatal("first Send should succeed when queue has space")
+	}
+	if h.Send("c2", common.WSMessage{Type: common.WSMsgLog}) {
+		t.Error("Send should return false when channel is full")
+	}
+}
+
+func TestHub_Register_NewClient(t *testing.T) {
+	h := NewHub()
+	conn := makeTestConn("c3", 8)
+	// register() with no prior entry for c3 must not close any ws.
+	h.register(conn)
+	if !h.IsConnected("c3") {
+		t.Error("IsConnected should be true after register")
+	}
+}
+
+func TestHub_Unregister_Unknown(t *testing.T) {
+	// Unregistering a client that was never registered should not panic.
+	h := NewHub()
+	h.unregister("nobody")
+	if h.IsConnected("nobody") {
+		t.Error("IsConnected should be false for unknown client")
+	}
+}
+
+// ── writeJSON / writeError ────────────────────────────────────────────────────
+
+func TestWriteJSON_SetsHeaderAndBody(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeJSON(rr, http.StatusCreated, map[string]string{"hello": "world"})
+
+	if rr.Code != http.StatusCreated {
+		t.Errorf("status = %d; want 201", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+	var got map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["hello"] != "world" {
+		t.Errorf("body[hello] = %q; want world", got["hello"])
+	}
+}
+
+func TestWriteError_WrapsInErrorField(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeError(rr, http.StatusBadRequest, "something went wrong")
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d; want 400", rr.Code)
+	}
+	var got map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["error"] != "something went wrong" {
+		t.Errorf("error field = %q; want 'something went wrong'", got["error"])
+	}
+}


### PR DESCRIPTION
This pull request adds comprehensive negative-path and edge-case test coverage for configuration loading, authentication, WebSocket handling, and utility functions in the daemon's HTTP handler layer. It also updates project settings to allow line counting of handler source files. These changes improve the robustness and reliability of the codebase by ensuring error cases are well-tested and handler utilities behave as expected.

**Test coverage improvements:**

* Added extensive negative-path tests for configuration loading in `config_test.go`, covering corrupted YAML, missing files, and validation errors for all config types.
* Introduced a new test suite in `auth_table_test.go` to cover various authentication scenarios, including malformed/expired/wrong-signature JWTs, missing/incorrect credentials, and UI login endpoint behaviors.
* Added a test for handling unknown WebSocket message types in `connect_internal_test.go`, ensuring such messages do not alter deployment state.
* Added a new test suite in `env_internal_test.go` for the `Hub` WebSocket connection manager, including tests for connection registration, message sending, queue limits, and utility functions for writing JSON/error responses.

**Project settings:**

* Updated `.claude/settings.json` to permit running `wc -l` on handler source files, supporting codebase metrics and analysis.