### PR TITLE
Rename all client references to Agent

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(grep -n \"^func\\\\|^type\\\\|^const\" /c/git/kompakt/internal/daemon/service/*.go)",
-      "Bash(wc -l /c/git/kompakt/internal/daemon/handlers/*.go)"
+      "Bash(wc -l /c/git/kompakt/internal/daemon/handlers/*.go)",
+      "Bash(grep -r \"\"\"clients\"\"\\\\|clients\\\\.html\\\\|clients-table\\\\|partials/clients\" internal/ --include=\"*.go\")"
     ]
   }
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -27,8 +27,8 @@ var errTokenRejected = errors.New("token rejected by server")
 
 // localState is persisted to disk so the agent can resume after a reboot.
 type localState struct {
-	ClientID string `json:"client_id"`
-	Token    string `json:"token"`
+	AgentID string `json:"agent_id"`
+	Token   string `json:"token"`
 }
 
 // Agent is the kompakt deployment agent.
@@ -108,9 +108,9 @@ func (c *Agent) register(ctx context.Context) error {
 	if err := c.post(ctx, "/api/v1/register", req, &resp, ""); err != nil {
 		return err
 	}
-	c.state.ClientID = resp.ClientID
+	c.state.AgentID = resp.AgentID
 	c.state.Token = resp.Token
-	log.Printf("registered as agent %s", c.state.ClientID)
+	log.Printf("registered as agent %s", c.state.AgentID)
 	return c.saveState()
 }
 
@@ -124,7 +124,7 @@ func (c *Agent) connect(ctx context.Context) error {
 		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
 			log.Printf("token rejected by server, will re-register")
 			c.state.Token = ""
-			c.state.ClientID = ""
+			c.state.AgentID = ""
 			_ = c.saveState()
 			return errTokenRejected
 		}

--- a/internal/agent/agent_internal_test.go
+++ b/internal/agent/agent_internal_test.go
@@ -35,7 +35,7 @@ func TestSaveLoadStateRoundTrip(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state.json")
 	cfg := &common.AgentConfig{StateFile: stateFile}
 	c := New(cfg)
-	c.state = localState{ClientID: "c1", Token: "t1"}
+	c.state = localState{AgentID: "c1", Token: "t1"}
 
 	if err := c.saveState(); err != nil {
 		t.Fatalf("saveState: %v", err)
@@ -45,7 +45,7 @@ func TestSaveLoadStateRoundTrip(t *testing.T) {
 	if err := c2.loadState(); err != nil {
 		t.Fatalf("loadState: %v", err)
 	}
-	if c2.state.ClientID != "c1" || c2.state.Token != "t1" {
+	if c2.state.AgentID != "c1" || c2.state.Token != "t1" {
 		t.Fatalf("loaded state mismatch: %+v", c2.state)
 	}
 }
@@ -93,8 +93,8 @@ func TestRegisterSuccess(t *testing.T) {
 			return
 		}
 		_ = json.NewEncoder(w).Encode(common.RegistrationResponse{
-			ClientID: "client-reg-1",
-			Token:    "token-reg-1",
+			AgentID: "agent-reg-1",
+			Token:   "token-reg-1",
 		})
 	}))
 	defer ts.Close()
@@ -109,7 +109,7 @@ func TestRegisterSuccess(t *testing.T) {
 	if err := c.register(context.Background()); err != nil {
 		t.Fatalf("register: %v", err)
 	}
-	if c.state.ClientID != "client-reg-1" || c.state.Token != "token-reg-1" {
+	if c.state.AgentID != "agent-reg-1" || c.state.Token != "token-reg-1" {
 		t.Fatalf("unexpected state after register: %+v", c.state)
 	}
 	if _, err := os.Stat(stateFile); err != nil {
@@ -129,14 +129,14 @@ func TestConnectUnauthorizedClearsState(t *testing.T) {
 
 	stateFile := filepath.Join(t.TempDir(), "state.json")
 	c := New(&common.AgentConfig{ServerURL: ts.URL, StateFile: stateFile})
-	c.state.ClientID = "c1"
+	c.state.AgentID = "c1"
 	c.state.Token = "t1"
 
 	err := c.connect(context.Background())
 	if !errors.Is(err, errTokenRejected) {
 		t.Fatalf("expected errTokenRejected, got %v", err)
 	}
-	if c.state.ClientID != "" || c.state.Token != "" {
+	if c.state.AgentID != "" || c.state.Token != "" {
 		t.Fatalf("state should be cleared after token rejection, got %+v", c.state)
 	}
 }

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -1,4 +1,4 @@
-// Package common defines shared types used by both the daemon and client.
+// Package common defines shared types used by both the daemon and agent.
 package common
 
 import (
@@ -117,7 +117,7 @@ func ResolveEnvSecrets(env map[string]string, secrets map[string]string) map[str
 	return out
 }
 
-// ── Client / registration types ───────────────────────────────────────────────
+// ── Agent / registration types ────────────────────────────────────────────────
 
 // PlatformType identifies the operating system platform.
 type PlatformType string
@@ -128,7 +128,7 @@ const (
 	PlatformWindows PlatformType = "windows"
 )
 
-// RegistrationRequest is sent by a client to POST /api/v1/register.
+// RegistrationRequest is sent by an agent to POST /api/v1/register.
 type RegistrationRequest struct {
 	Platform           PlatformType      `json:"platform"`
 	Hostname           string            `json:"hostname"`
@@ -138,26 +138,26 @@ type RegistrationRequest struct {
 	Metadata           map[string]string `json:"metadata,omitempty"`
 }
 
-// RegistrationResponse is returned to a successfully registered client.
+// RegistrationResponse is returned to a successfully registered agent.
 type RegistrationResponse struct {
-	ClientID string `json:"client_id"`
-	Token    string `json:"token"`
+	AgentID string `json:"agent_id"`
+	Token   string `json:"token"`
 }
 
-// ClientStatus represents the lifecycle state of a registered client.
-type ClientStatus string
+// AgentStatus represents the lifecycle state of a registered agent.
+type AgentStatus string
 
 const (
-	ClientStatusRegistered ClientStatus = "registered"
-	ClientStatusConnected  ClientStatus = "connected"
-	ClientStatusDeploying  ClientStatus = "deploying"
-	ClientStatusDone       ClientStatus = "done"
-	ClientStatusFailed     ClientStatus = "failed"
-	ClientStatusOffline    ClientStatus = "offline"
+	AgentStatusRegistered AgentStatus = "registered"
+	AgentStatusConnected  AgentStatus = "connected"
+	AgentStatusDeploying  AgentStatus = "deploying"
+	AgentStatusDone       AgentStatus = "done"
+	AgentStatusFailed     AgentStatus = "failed"
+	AgentStatusOffline    AgentStatus = "offline"
 )
 
-// Client holds server-side information about a registered client machine.
-type Client struct {
+// Agent holds server-side information about a registered agent machine.
+type Agent struct {
 	ID             string            `json:"id"`
 	Hostname       string            `json:"hostname"`
 	Platform       PlatformType      `json:"platform"`
@@ -166,7 +166,7 @@ type Client struct {
 	Vendor         string            `json:"vendor,omitempty"`
 	IPAddress      string            `json:"ip_address,omitempty"`
 	Metadata       map[string]string `json:"metadata,omitempty"`
-	Status         ClientStatus      `json:"status"`
+	Status         AgentStatus       `json:"status"`
 	PlaybookID     string            `json:"playbook_id,omitempty"`
 	RegisteredAt   time.Time         `json:"registered_at"`
 	LastActivityAt time.Time         `json:"last_activity_at"`
@@ -186,11 +186,11 @@ const (
 )
 
 // DeploymentState is persisted on the server for each active deployment.
-// ResumeStepIndex is the flat global step index the client should start from
+// ResumeStepIndex is the flat global step index the agent should start from
 // on the next connect (used after a reboot).
 type DeploymentState struct {
 	ID              string           `json:"id"`
-	ClientID        string           `json:"client_id"`
+	AgentID         string           `json:"agent_id"`
 	Hostname        string           `json:"hostname,omitempty"`
 	PlaybookID      string           `json:"playbook_id"`
 	PlaybookName    string           `json:"playbook_name,omitempty"`
@@ -214,7 +214,7 @@ const (
 	LogLevelError LogLevel = "error"
 )
 
-// LogEntry represents a single log line from a client step.
+// LogEntry represents a single log line from an agent step.
 type LogEntry struct {
 	DeploymentID string    `json:"deployment_id"`
 	JobName      string    `json:"job_name"`
@@ -237,9 +237,9 @@ type Artifact struct {
 	Filename       string       `json:"filename"`
 	Size           int64        `json:"size"`
 	ContentType    string       `json:"content_type"`
-	AccessPolicy   AccessPolicy `json:"access_policy"`
-	AllowedClients []string     `json:"allowed_clients,omitempty"`
-	UploadedAt     time.Time    `json:"uploaded_at"`
+	AccessPolicy  AccessPolicy `json:"access_policy"`
+	AllowedAgents []string     `json:"allowed_agents,omitempty"`
+	UploadedAt    time.Time    `json:"uploaded_at"`
 }
 
 // AccessPolicy defines who can download an artifact.
@@ -247,8 +247,8 @@ type AccessPolicy string
 
 const (
 	AccessPublic        AccessPolicy = "public"        // anyone
-	AccessAuthenticated AccessPolicy = "authenticated" // any client/user
-	AccessRestricted    AccessPolicy = "restricted"    // specific clients only
+	AccessAuthenticated AccessPolicy = "authenticated" // any agent/user
+	AccessRestricted    AccessPolicy = "restricted"    // specific agents only
 )
 
 // ── WebSocket protocol types ──────────────────────────────────────────────────
@@ -261,12 +261,12 @@ const (
 	WSMsgPlaybook WSMessageType = "playbook" // push deployment instructions
 	WSMsgPing     WSMessageType = "ping"
 
-	// Client → Server
+	// Agent → Server
 	WSMsgLog          WSMessageType = "log"           // stream a log line
 	WSMsgStepStart    WSMessageType = "step_start"    // step beginning
 	WSMsgStepComplete WSMessageType = "step_complete" // step succeeded
 	WSMsgStepFailed   WSMessageType = "step_failed"   // step error
-	WSMsgReboot       WSMessageType = "reboot"        // client about to reboot
+	WSMsgReboot       WSMessageType = "reboot"        // agent about to reboot
 	WSMsgDeployDone   WSMessageType = "deploy_done"   // all steps complete
 	WSMsgDeployFailed WSMessageType = "deploy_failed" // fatal deployment error
 	WSMsgPong         WSMessageType = "pong"

--- a/internal/server/handlers/admin.go
+++ b/internal/server/handlers/admin.go
@@ -19,7 +19,7 @@ import (
 
 // StatusResponse is returned by GET /api/v1/status (JSON) and used by the /ui status dashboard.
 type StatusResponse struct {
-	Clients     []*common.Client          `json:"clients"`
+	Agents      []*common.Agent           `json:"agents"`
 	Deployments []*common.DeploymentState `json:"deployments"`
 }
 
@@ -32,8 +32,8 @@ type StatusResponse struct {
 //	GET    /api/v1/playbooks/{id}         – get one
 //	PUT    /api/v1/playbooks/{id}         – update
 //	DELETE /api/v1/playbooks/{id}         – delete
-//	POST   /api/v1/playbooks/{id}/assign  – assign to a client (pushes immediately
-//	                                         if client is connected via WebSocket)
+//	POST   /api/v1/playbooks/{id}/assign  – assign to an agent (pushes immediately
+//	                                         if agent is connected via WebSocket)
 func (e *Handler) HandleRootPlaybooks(w http.ResponseWriter, r *http.Request) {
 	// Strip prefix to isolate the path tail.
 	tail := strings.TrimPrefix(r.URL.Path, "/api/v1/playbooks")
@@ -183,11 +183,11 @@ func decodePlaybookWritePayload(r *http.Request) (store.PlaybookRecord, error) {
 	return out, nil
 }
 
-// assignPlaybook assigns a playbook to a client and immediately pushes it
-// if the client is connected via WebSocket.
+// assignPlaybook assigns a playbook to an agent and immediately pushes it
+// if the agent is connected via WebSocket.
 func (e *Handler) assignPlaybook(w http.ResponseWriter, r *http.Request, playbookID string) {
 	var body struct {
-		ClientID string `json:"client_id"`
+		AgentID string `json:"agent_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -197,9 +197,9 @@ func (e *Handler) assignPlaybook(w http.ResponseWriter, r *http.Request, playboo
 		writeError(w, http.StatusInternalServerError, "service not configured")
 		return
 	}
-	if err := e.Service.AssignPlaybookToClient(playbookID, body.ClientID); err != nil {
+	if err := e.Service.AssignPlaybookToAgent(playbookID, body.AgentID); err != nil {
 		switch {
-		case errors.Is(err, service.ErrClientNotFound), errors.Is(err, service.ErrPlaybookNotFound):
+		case errors.Is(err, service.ErrAgentNotFound), errors.Is(err, service.ErrPlaybookNotFound):
 			writeError(w, http.StatusNotFound, err.Error())
 		default:
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -209,45 +209,45 @@ func (e *Handler) assignPlaybook(w http.ResponseWriter, r *http.Request, playboo
 	writeJSON(w, http.StatusOK, map[string]string{"status": "assigned"})
 }
 
-// ── /api/v1/clients ───────────────────────────────────────────────────────────────
+// ── /api/v1/agents ────────────────────────────────────────────────────────────────
 
-// HandleRootClients dispatches CRUD on clients.
+// HandleRootAgents dispatches CRUD on agents.
 //
-//	GET    /api/v1/clients          – list all
-//	GET    /api/v1/clients/{id}     – get one
-//	PUT    /api/v1/clients/{id}     – update (e.g. assign playbook, set status)
-//	DELETE /api/v1/clients/{id}     – delete
-func (e *Handler) HandleRootClients(w http.ResponseWriter, r *http.Request) {
-	tail := strings.TrimPrefix(r.URL.Path, "/api/v1/clients")
+//	GET    /api/v1/agents          – list all
+//	GET    /api/v1/agents/{id}     – get one
+//	PUT    /api/v1/agents/{id}     – update (e.g. assign playbook, set status)
+//	DELETE /api/v1/agents/{id}     – delete
+func (e *Handler) HandleRootAgents(w http.ResponseWriter, r *http.Request) {
+	tail := strings.TrimPrefix(r.URL.Path, "/api/v1/agents")
 	tail = strings.TrimPrefix(tail, "/")
 	id := tail
 
 	switch r.Method {
 	case http.MethodGet:
 		if id == "" {
-			writeJSON(w, http.StatusOK, e.Store.ListClients())
+			writeJSON(w, http.StatusOK, e.Store.ListAgents())
 			return
 		}
-		c, ok := e.Store.GetClient(id)
+		a, ok := e.Store.GetAgent(id)
 		if !ok {
-			writeError(w, http.StatusNotFound, "client not found")
+			writeError(w, http.StatusNotFound, "agent not found")
 			return
 		}
-		writeJSON(w, http.StatusOK, c)
+		writeJSON(w, http.StatusOK, a)
 
 	case http.MethodPut:
 		if id == "" {
-			writeError(w, http.StatusBadRequest, "client ID required in path")
+			writeError(w, http.StatusBadRequest, "agent ID required in path")
 			return
 		}
-		existing, ok := e.Store.GetClient(id)
+		existing, ok := e.Store.GetAgent(id)
 		if !ok {
-			writeError(w, http.StatusNotFound, "client not found")
+			writeError(w, http.StatusNotFound, "agent not found")
 			return
 		}
 		var patch struct {
-			PlaybookID string              `json:"playbook_id"`
-			Status     common.ClientStatus `json:"status"`
+			PlaybookID string             `json:"playbook_id"`
+			Status     common.AgentStatus `json:"status"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
@@ -259,19 +259,19 @@ func (e *Handler) HandleRootClients(w http.ResponseWriter, r *http.Request) {
 		if patch.Status != "" {
 			existing.Status = patch.Status
 		}
-		if err := e.Store.SaveClient(existing); err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to update client")
+		if err := e.Store.SaveAgent(existing); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to update agent")
 			return
 		}
 		writeJSON(w, http.StatusOK, existing)
 
 	case http.MethodDelete:
 		if id == "" {
-			writeError(w, http.StatusBadRequest, "client ID required in path")
+			writeError(w, http.StatusBadRequest, "agent ID required in path")
 			return
 		}
-		if err := e.Store.DeleteClient(id); err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to delete client")
+		if err := e.Store.DeleteAgent(id); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to delete agent")
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
@@ -339,14 +339,13 @@ func (e *Handler) HandleStatus(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
-	clients := e.Store.ListClients()
+	agents := e.Store.ListAgents()
 	deployments := e.Store.ListDeployments()
 	if e.Service != nil {
-		clients, deployments = e.Service.StatusSnapshot()
+		agents, deployments = e.Service.StatusSnapshot()
 	}
 	writeJSON(w, http.StatusOK, StatusResponse{
-		Clients:     clients,
+		Agents:      agents,
 		Deployments: deployments,
 	})
 }
-

--- a/internal/server/handlers/artifacts.go
+++ b/internal/server/handlers/artifacts.go
@@ -37,7 +37,7 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 		if id == "" {
 			// Listing requires authentication (root or any client)
 			if !e.isRootRequest(r) {
-				if _, err := e.clientIDFromToken(r); err != nil {
+				if _, err := e.agentIDFromToken(r); err != nil {
 					writeError(w, http.StatusUnauthorized, "authentication required to list artifacts")
 					return
 				}
@@ -68,16 +68,16 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 		if a.AccessPolicy != common.AccessPublic {
 			// Check for root auth first
 			if !e.isRootRequest(r) {
-				// Check for client auth
-				clientID, err := e.clientIDFromToken(r)
+				// Check for agent auth
+				agentID, err := e.agentIDFromToken(r)
 				if err != nil {
 					writeError(w, http.StatusUnauthorized, "authenticated access required")
 					return
 				}
 				if a.AccessPolicy == common.AccessRestricted {
 					allowed := false
-					for _, cid := range a.AllowedClients {
-						if cid == clientID {
+					for _, aid := range a.AllowedAgents {
+						if aid == agentID {
 							allowed = true
 							break
 						}
@@ -108,7 +108,7 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		// Upload requires authentication (root or any client)
 		if !e.isRootRequest(r) {
-			if _, err := e.clientIDFromToken(r); err != nil {
+			if _, err := e.agentIDFromToken(r); err != nil {
 				writeError(w, http.StatusUnauthorized, "authentication required to upload artifacts")
 				return
 			}
@@ -158,14 +158,14 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 			Size:           size,
 			ContentType:    ct,
 			AccessPolicy:   common.AccessPolicy(r.URL.Query().Get("access_policy")),
-			AllowedClients: strings.Split(r.URL.Query().Get("allowed_clients"), ","),
+			AllowedAgents: strings.Split(r.URL.Query().Get("allowed_agents"), ","),
 			UploadedAt:     time.Now(),
 		}
 		if art.AccessPolicy == "" {
 			art.AccessPolicy = common.AccessAuthenticated // default
 		}
-		if len(art.AllowedClients) == 1 && art.AllowedClients[0] == "" {
-			art.AllowedClients = nil
+		if len(art.AllowedAgents) == 1 && art.AllowedAgents[0] == "" {
+			art.AllowedAgents = nil
 		}
 		if err := e.Store.SaveArtifact(art); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to save artifact metadata")
@@ -176,7 +176,7 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPatch:
 		// Update metadata requires authentication (root or any client)
 		if !e.isRootRequest(r) {
-			if _, err := e.clientIDFromToken(r); err != nil {
+			if _, err := e.agentIDFromToken(r); err != nil {
 				writeError(w, http.StatusUnauthorized, "authentication required to modify artifacts")
 				return
 			}
@@ -192,7 +192,7 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 		}
 
 		policy := r.URL.Query().Get("access_policy")
-		allowedClients := r.URL.Query().Get("allowed_clients")
+		allowedClients := r.URL.Query().Get("allowed_agents")
 
 		if policy != "" {
 			a.AccessPolicy = common.AccessPolicy(policy)
@@ -206,9 +206,9 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 					filtered = append(filtered, c)
 				}
 			}
-			a.AllowedClients = filtered
-		} else if r.URL.Query().Has("allowed_clients") {
-			a.AllowedClients = nil
+			a.AllowedAgents = filtered
+		} else if r.URL.Query().Has("allowed_agents") {
+			a.AllowedAgents = nil
 		}
 
 		if err := e.Store.SaveArtifact(a); err != nil {
@@ -220,7 +220,7 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		// Delete requires authentication (root or any client)
 		if !e.isRootRequest(r) {
-			if _, err := e.clientIDFromToken(r); err != nil {
+			if _, err := e.agentIDFromToken(r); err != nil {
 				writeError(w, http.StatusUnauthorized, "authentication required to delete artifacts")
 				return
 			}

--- a/internal/server/handlers/auth.go
+++ b/internal/server/handlers/auth.go
@@ -21,14 +21,14 @@ const uiTokenAudience = "kompakt-ui"
 
 // ── JWT helpers ───────────────────────────────────────────────────────────────
 
-// issueToken signs a JWT for the given client ID.
-func (e *Handler) issueToken(clientID string) (string, error) {
+// issueToken signs a JWT for the given agent ID.
+func (e *Handler) issueToken(agentID string) (string, error) {
 	expiry := time.Duration(e.TokenExpiryHours) * time.Hour
 	if expiry == 0 {
 		expiry = 720 * time.Hour // 30 days default
 	}
 	claims := jwt.RegisteredClaims{
-		Subject:   clientID,
+		Subject:   agentID,
 		IssuedAt:  jwt.NewNumericDate(time.Now()),
 		ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiry)),
 	}
@@ -36,12 +36,12 @@ func (e *Handler) issueToken(clientID string) (string, error) {
 	return tok.SignedString(e.AgentJWTSecret)
 }
 
-// clientIDFromToken validates the Bearer token in the request and returns
-// the embedded client ID.
-func (e *Handler) clientIDFromToken(r *http.Request) (string, error) {
+// agentIDFromToken validates the Bearer token in the request and returns
+// the embedded agent ID.
+func (e *Handler) agentIDFromToken(r *http.Request) (string, error) {
 	auth := r.Header.Get("Authorization")
 	if !strings.HasPrefix(auth, "Bearer ") {
-		// Also accept token as query parameter (for WebSocket clients that
+		// Also accept token as query parameter (for WebSocket agents that
 		// cannot set headers during the handshake).
 		token := r.URL.Query().Get("token")
 		if token == "" {
@@ -82,23 +82,23 @@ func (e *Handler) parseToken(raw string) (string, error) {
 
 // ── Middleware ────────────────────────────────────────────────────────────────
 
-// RequireAgentAuth validates the client JWT and sets X-Client-ID for
-// downstream handlers. Also refreshes the client's last-seen timestamp.
+// RequireAgentAuth validates the agent JWT and sets X-Agent-ID for
+// downstream handlers. Also refreshes the agent's last-seen timestamp.
 func (e *Handler) RequireAgentAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		clientID, err := e.clientIDFromToken(r)
+		agentID, err := e.agentIDFromToken(r)
 		if err != nil {
 			writeError(w, http.StatusUnauthorized, err.Error())
 			return
 		}
-		if c, ok := e.Store.GetClient(clientID); ok {
-			c.LastActivityAt = time.Now()
-			if c.Status == common.ClientStatusOffline {
-				c.Status = common.ClientStatusConnected
+		if a, ok := e.Store.GetAgent(agentID); ok {
+			a.LastActivityAt = time.Now()
+			if a.Status == common.AgentStatusOffline {
+				a.Status = common.AgentStatusConnected
 			}
-			_ = e.Store.SaveClient(c)
+			_ = e.Store.SaveAgent(a)
 		}
-		r.Header.Set("X-Client-ID", clientID)
+		r.Header.Set("X-Agent-ID", agentID)
 		next.ServeHTTP(w, r)
 	})
 }
@@ -190,8 +190,8 @@ func (e *Handler) HandleUILogin(w http.ResponseWriter, r *http.Request) {
 // ── Registration ─────────────────────────────────────────────────────────────
 
 // HandleAgentRegister processes POST /api/v1/register.
-// Clients authenticate with a pre-shared registration secret.
-// Re-registration of the same machine_id is idempotent — the existing client
+// Agents authenticate with a pre-shared registration secret.
+// Re-registration of the same machine_id is idempotent — the existing agent
 // record is reused and a fresh JWT is issued.
 func (e *Handler) HandleAgentRegister(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -219,55 +219,55 @@ func (e *Handler) HandleAgentRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reuse existing client record when the same machine_id re-registers
-	// (e.g., after an OS re-image that cleared the client state file).
-	var client *common.Client
+	// Reuse existing agent record when the same machine_id re-registers
+	// (e.g., after an OS re-image that cleared the agent state file).
+	var agent *common.Agent
 	machineID := strings.TrimSpace(req.Metadata["machine_id"])
 	if machineID != "" {
-		for _, c := range e.Store.ListClients() {
-			if strings.TrimSpace(c.Metadata["machine_id"]) == machineID {
-				client = c
+		for _, a := range e.Store.ListAgents() {
+			if strings.TrimSpace(a.Metadata["machine_id"]) == machineID {
+				agent = a
 				break
 			}
 		}
 	}
-	if client == nil {
-		client = &common.Client{
+	if agent == nil {
+		agent = &common.Agent{
 			ID:           common.NewID(),
 			RegisteredAt: time.Now(),
 		}
 	}
-	client.Hostname = req.Hostname
-	client.Platform = req.Platform
-	client.OS = strings.TrimSpace(req.Metadata["os"])
-	if client.OS == "" {
-		client.OS = strings.TrimSpace(req.Metadata["os_description"])
+	agent.Hostname = req.Hostname
+	agent.Platform = req.Platform
+	agent.OS = strings.TrimSpace(req.Metadata["os"])
+	if agent.OS == "" {
+		agent.OS = strings.TrimSpace(req.Metadata["os_description"])
 	}
-	client.Model = strings.TrimSpace(req.Model)
-	if client.Model == "" {
-		client.Model = strings.TrimSpace(req.Metadata["model"])
+	agent.Model = strings.TrimSpace(req.Model)
+	if agent.Model == "" {
+		agent.Model = strings.TrimSpace(req.Metadata["model"])
 	}
-	client.Vendor = strings.TrimSpace(req.Vendor)
-	if client.Vendor == "" {
-		client.Vendor = strings.TrimSpace(req.Metadata["vendor"])
+	agent.Vendor = strings.TrimSpace(req.Vendor)
+	if agent.Vendor == "" {
+		agent.Vendor = strings.TrimSpace(req.Metadata["vendor"])
 	}
-	client.IPAddress = requestIP(r)
-	client.Metadata = req.Metadata
-	client.Status = common.ClientStatusRegistered
-	client.LastActivityAt = time.Now()
+	agent.IPAddress = requestIP(r)
+	agent.Metadata = req.Metadata
+	agent.Status = common.AgentStatusRegistered
+	agent.LastActivityAt = time.Now()
 
-	if err := e.Store.SaveClient(client); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to save client")
+	if err := e.Store.SaveAgent(agent); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to save agent")
 		return
 	}
-	token, err := e.issueToken(client.ID)
+	token, err := e.issueToken(agent.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to issue token")
 		return
 	}
 	writeJSON(w, http.StatusOK, common.RegistrationResponse{
-		ClientID: client.ID,
-		Token:    token,
+		AgentID: agent.ID,
+		Token:   token,
 	})
 }
 

--- a/internal/server/handlers/handler.go
+++ b/internal/server/handlers/handler.go
@@ -33,12 +33,12 @@ type Handler struct {
 // Hub manages all active WebSocket connections.
 type Hub struct {
 	mu    sync.RWMutex
-	conns map[string]*WSConn // clientID → connection
+	conns map[string]*WSConn // agentID → connection
 }
 
-// WSConn wraps a single client WebSocket connection with an outbound queue.
+// WSConn wraps a single agent WebSocket connection with an outbound queue.
 type WSConn struct {
-	clientID string
+	agentID string
 	ws       *websocket.Conn
 	send     chan []byte
 	done     chan struct{}
@@ -49,43 +49,43 @@ func NewHub() *Hub {
 	return &Hub{conns: make(map[string]*WSConn)}
 }
 
-// register adds (or replaces) the connection for a client.
+// register adds (or replaces) the connection for an agent.
 func (h *Hub) register(conn *WSConn) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if old, ok := h.conns[conn.clientID]; ok {
+	if old, ok := h.conns[conn.agentID]; ok {
 		close(old.done)
 		_ = old.ws.Close()
 	}
-	h.conns[conn.clientID] = conn
+	h.conns[conn.agentID] = conn
 }
 
-// unregister removes the connection for a client.
-func (h *Hub) unregister(clientID string) {
+// unregister removes the connection for an agent.
+func (h *Hub) unregister(agentID string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	delete(h.conns, clientID)
+	delete(h.conns, agentID)
 }
 
-// IsConnected reports whether a client has an open WebSocket connection.
-func (h *Hub) IsConnected(clientID string) bool {
+// IsConnected reports whether an agent has an open WebSocket connection.
+func (h *Hub) IsConnected(agentID string) bool {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	_, ok := h.conns[clientID]
+	_, ok := h.conns[agentID]
 	return ok
 }
 
-// Send queues a message for the named client. Returns false if not connected.
-func (h *Hub) Send(clientID string, msg common.WSMessage) bool {
+// Send queues a message for the named agent. Returns false if not connected.
+func (h *Hub) Send(agentID string, msg common.WSMessage) bool {
 	h.mu.RLock()
-	conn, ok := h.conns[clientID]
+	conn, ok := h.conns[agentID]
 	h.mu.RUnlock()
 	if !ok {
 		return false
 	}
 	data, err := json.Marshal(msg)
 	if err != nil {
-		slog.Error("failed to marshal websocket message", "client_id", clientID, "msg_type", msg.Type, "err", err)
+		slog.Error("failed to marshal websocket message", "agent_id", agentID, "msg_type", msg.Type, "err", err)
 		return false
 	}
 	select {
@@ -97,9 +97,9 @@ func (h *Hub) Send(clientID string, msg common.WSMessage) bool {
 }
 
 // newWSConn creates a WSConn and starts its write pump goroutine.
-func newWSConn(clientID string, ws *websocket.Conn) *WSConn {
+func newWSConn(agentID string, ws *websocket.Conn) *WSConn {
 	c := &WSConn{
-		clientID: clientID,
+		agentID: agentID,
 		ws:       ws,
 		send:     make(chan []byte, 64),
 		done:     make(chan struct{}),

--- a/internal/server/handlers/handler_internal_test.go
+++ b/internal/server/handlers/handler_internal_test.go
@@ -11,11 +11,11 @@ import (
 
 // makeTestConn builds a WSConn suitable for unit tests: the ws field is nil
 // because Hub.Send and Hub.IsConnected never touch it.
-func makeTestConn(clientID string, bufSize int) *WSConn {
+func makeTestConn(agentID string, bufSize int) *WSConn {
 	return &WSConn{
-		clientID: clientID,
-		send:     make(chan []byte, bufSize),
-		done:     make(chan struct{}),
+		agentID: agentID,
+		send:    make(chan []byte, bufSize),
+		done:    make(chan struct{}),
 	}
 }
 
@@ -38,7 +38,7 @@ func TestHub_IsConnectedAndSend(t *testing.T) {
 	}
 
 	if !h.Send("c1", common.WSMessage{Type: common.WSMsgLog}) {
-		t.Fatal("Send should return true for connected client")
+		t.Fatal("Send should return true for connected agent")
 	}
 
 	select {
@@ -63,7 +63,7 @@ func TestHub_IsConnectedAndSend(t *testing.T) {
 func TestHub_Send_NotConnected(t *testing.T) {
 	h := NewHub()
 	if h.Send("ghost", common.WSMessage{Type: common.WSMsgLog}) {
-		t.Error("Send should return false for unconnected client")
+		t.Error("Send should return false for unconnected agent")
 	}
 }
 
@@ -82,7 +82,7 @@ func TestHub_Send_QueueFull(t *testing.T) {
 	}
 }
 
-func TestHub_Register_NewClient(t *testing.T) {
+func TestHub_Register_NewAgent(t *testing.T) {
 	h := NewHub()
 	conn := makeTestConn("c3", 8)
 	// register() with no prior entry for c3 must not close any ws.
@@ -93,11 +93,11 @@ func TestHub_Register_NewClient(t *testing.T) {
 }
 
 func TestHub_Unregister_Unknown(t *testing.T) {
-	// Unregistering a client that was never registered should not panic.
+	// Unregistering an agent that was never registered should not panic.
 	h := NewHub()
 	h.unregister("nobody")
 	if h.IsConnected("nobody") {
-		t.Error("IsConnected should be false for unknown client")
+		t.Error("IsConnected should be false for unknown agent")
 	}
 }
 

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -41,10 +41,10 @@ func newTestEnv(t *testing.T) *handlers.Handler {
 
 func postJSON(t *testing.T, handler http.HandlerFunc, path string, body any, token string) *httptest.ResponseRecorder {
 	t.Helper()
-	return requestWithClientID(t, http.MethodPost, handler, path, body, token, "")
+	return requestWithAgentID(t, http.MethodPost, handler, path, body, token, "")
 }
 
-func requestWithClientID(t *testing.T, method string, handler http.HandlerFunc, path string, body any, token, clientID string) *httptest.ResponseRecorder {
+func requestWithAgentID(t *testing.T, method string, handler http.HandlerFunc, path string, body any, token, agentID string) *httptest.ResponseRecorder {
 	t.Helper()
 	var bodyReader *bytes.Reader
 	if body != nil {
@@ -61,8 +61,8 @@ func requestWithClientID(t *testing.T, method string, handler http.HandlerFunc, 
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	if clientID != "" {
-		req.Header.Set("X-Client-ID", clientID)
+	if agentID != "" {
+		req.Header.Set("X-Agent-ID", agentID)
 	}
 	rr := httptest.NewRecorder()
 	handler(rr, req)
@@ -102,7 +102,7 @@ func registerAgent(t *testing.T, env *handlers.Handler, machineID, hostname stri
 		t.Fatalf("register: status=%d body=%s", rr.Code, rr.Body.String())
 	}
 	resp := decode[common.RegistrationResponse](t, rr)
-	return resp.ClientID, resp.Token
+	return resp.AgentID, resp.Token
 }
 
 // ── Registration ─────────────────────────────────────────────────────────────
@@ -118,8 +118,8 @@ func TestHandleRegister_Success(t *testing.T) {
 		t.Fatalf("status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
 	resp := decode[common.RegistrationResponse](t, rr)
-	if resp.ClientID == "" {
-		t.Error("ClientID is empty")
+	if resp.AgentID == "" {
+		t.Error("AgentID is empty")
 	}
 	if resp.Token == "" {
 		t.Error("Token is empty")
@@ -185,15 +185,15 @@ func TestHandleRegister_Idempotent(t *testing.T) {
 	r1 := decode[common.RegistrationResponse](t, rr1)
 	r2 := decode[common.RegistrationResponse](t, rr2)
 
-	if r1.ClientID != r2.ClientID {
-		t.Errorf("second registration should reuse client ID: %q != %q", r1.ClientID, r2.ClientID)
+	if r1.AgentID != r2.AgentID {
+		t.Errorf("second registration should reuse agent ID: %q != %q", r1.AgentID, r2.AgentID)
 	}
-	if len(r1.ClientID) != 26 {
-		t.Errorf("client_id %q is not a 26-char ULID", r1.ClientID)
+	if len(r1.AgentID) != 26 {
+		t.Errorf("agent_id %q is not a 26-char ULID", r1.AgentID)
 	}
 }
 
-func TestHandleRegister_ClientIDIsULID(t *testing.T) {
+func TestHandleRegister_AgentIDIsULID(t *testing.T) {
 	env := newTestEnv(t)
 	rr := postJSON(t, env.HandleAgentRegister, "/api/v1/register", common.RegistrationRequest{
 		Platform: common.PlatformLinux,
@@ -207,12 +207,12 @@ func TestHandleRegister_ClientIDIsULID(t *testing.T) {
 		t.Fatalf("status = %d (body: %s)", rr.Code, rr.Body.String())
 	}
 	resp := decode[common.RegistrationResponse](t, rr)
-	if len(resp.ClientID) != 26 {
-		t.Errorf("client_id %q is not a 26-char ULID", resp.ClientID)
+	if len(resp.AgentID) != 26 {
+		t.Errorf("agent_id %q is not a 26-char ULID", resp.AgentID)
 	}
 }
 
-func TestHandleRegister_CapturesClientIP(t *testing.T) {
+func TestHandleRegister_CapturesAgentIP(t *testing.T) {
 	env := newTestEnv(t)
 
 	body, err := json.Marshal(common.RegistrationRequest{
@@ -235,16 +235,16 @@ func TestHandleRegister_CapturesClientIP(t *testing.T) {
 	}
 
 	resp := decode[common.RegistrationResponse](t, rr)
-	client, ok := env.Store.GetClient(resp.ClientID)
+	agent, ok := env.Store.GetAgent(resp.AgentID)
 	if !ok {
-		t.Fatalf("client %q not found", resp.ClientID)
+		t.Fatalf("agent %q not found", resp.AgentID)
 	}
-	if client.IPAddress != "203.0.113.10" {
-		t.Errorf("ip_address = %q; want %q", client.IPAddress, "203.0.113.10")
+	if agent.IPAddress != "203.0.113.10" {
+		t.Errorf("ip_address = %q; want %q", agent.IPAddress, "203.0.113.10")
 	}
 }
 
-func TestHandleRegister_CapturesClientOS(t *testing.T) {
+func TestHandleRegister_CapturesAgentOS(t *testing.T) {
 	env := newTestEnv(t)
 
 	body, err := json.Marshal(common.RegistrationRequest{
@@ -271,18 +271,18 @@ func TestHandleRegister_CapturesClientOS(t *testing.T) {
 	}
 
 	resp := decode[common.RegistrationResponse](t, rr)
-	client, ok := env.Store.GetClient(resp.ClientID)
+	agent, ok := env.Store.GetAgent(resp.AgentID)
 	if !ok {
-		t.Fatalf("client %q not found", resp.ClientID)
+		t.Fatalf("agent %q not found", resp.AgentID)
 	}
-	if client.OS != "Debian GNU/Linux 12 (bookworm)" {
-		t.Errorf("os = %q; want %q", client.OS, "Debian GNU/Linux 12 (bookworm)")
+	if agent.OS != "Debian GNU/Linux 12 (bookworm)" {
+		t.Errorf("os = %q; want %q", agent.OS, "Debian GNU/Linux 12 (bookworm)")
 	}
-	if client.Model != "PowerEdge R650" {
-		t.Errorf("model = %q; want %q", client.Model, "PowerEdge R650")
+	if agent.Model != "PowerEdge R650" {
+		t.Errorf("model = %q; want %q", agent.Model, "PowerEdge R650")
 	}
-	if client.Vendor != "Dell Inc." {
-		t.Errorf("vendor = %q; want %q", client.Vendor, "Dell Inc.")
+	if agent.Vendor != "Dell Inc." {
+		t.Errorf("vendor = %q; want %q", agent.Vendor, "Dell Inc.")
 	}
 }
 
@@ -302,14 +302,14 @@ func TestRequireAgentAuth_Missing(t *testing.T) {
 
 func TestRequireAgentAuth_QueryToken(t *testing.T) {
 	env := newTestEnv(t)
-	clientID, token := registerAgent(t, env, "SN-QUERY-01", "query-client")
+	agentID, token := registerAgent(t, env, "SN-QUERY-01", "query-client")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws?token="+token, nil)
 	rr := httptest.NewRecorder()
 
 	env.RequireAgentAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("X-Client-ID"); got != clientID {
-			t.Fatalf("X-Client-ID = %q; want %q", got, clientID)
+		if got := r.Header.Get("X-Agent-ID"); got != agentID {
+			t.Fatalf("X-Agent-ID = %q; want %q", got, agentID)
 		}
 		w.WriteHeader(http.StatusOK)
 	})).ServeHTTP(rr, req)
@@ -367,8 +367,8 @@ func TestHandleStatus(t *testing.T) {
 		t.Fatalf("status = %d", rr.Code)
 	}
 	resp := decode[handlers.StatusResponse](t, rr)
-	if len(resp.Clients) != 1 {
-		t.Errorf("clients = %d; want 1", len(resp.Clients))
+	if len(resp.Agents) != 1 {
+		t.Errorf("agents = %d; want 1", len(resp.Agents))
 	}
 }
 
@@ -505,15 +505,15 @@ func TestHandleRootPlaybooks_Assign(t *testing.T) {
 	env := newTestEnv(t)
 	now := time.Now()
 
-	if err := env.Store.SaveClient(&common.Client{
+	if err := env.Store.SaveAgent(&common.Agent{
 		ID:             "client-assign-1",
 		Hostname:       "edge-assign",
 		Platform:       common.PlatformLinux,
-		Status:         common.ClientStatusRegistered,
+		Status:         common.AgentStatusRegistered,
 		RegisteredAt:   now,
 		LastActivityAt: now,
 	}); err != nil {
-		t.Fatalf("SaveClient: %v", err)
+		t.Fatalf("SaveAgent: %v", err)
 	}
 	if err := env.Store.SavePlaybook(&store.PlaybookRecord{
 		ID:   "pb-assign-1",
@@ -529,7 +529,7 @@ func TestHandleRootPlaybooks_Assign(t *testing.T) {
 	}
 
 	t.Run("success", func(t *testing.T) {
-		b, _ := json.Marshal(map[string]string{"client_id": "client-assign-1"})
+		b, _ := json.Marshal(map[string]string{"agent_id": "client-assign-1"})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/playbooks/pb-assign-1/assign", bytes.NewReader(b))
 		req.URL.Path = "/api/v1/playbooks/pb-assign-1/assign"
 		req.Header.Set("Content-Type", "application/json")
@@ -540,9 +540,9 @@ func TestHandleRootPlaybooks_Assign(t *testing.T) {
 			t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
 		}
 
-		c, ok := env.Store.GetClient("client-assign-1")
+		c, ok := env.Store.GetAgent("client-assign-1")
 		if !ok {
-			t.Fatal("client not found")
+			t.Fatal("agent not found")
 		}
 		if c.PlaybookID != "pb-assign-1" {
 			t.Fatalf("PlaybookID = %q; want pb-assign-1", c.PlaybookID)
@@ -560,8 +560,8 @@ func TestHandleRootPlaybooks_Assign(t *testing.T) {
 		}
 	})
 
-	t.Run("missing client", func(t *testing.T) {
-		b, _ := json.Marshal(map[string]string{"client_id": "no-client"})
+	t.Run("missing agent", func(t *testing.T) {
+		b, _ := json.Marshal(map[string]string{"agent_id": "no-agent"})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/playbooks/pb-assign-1/assign", bytes.NewReader(b))
 		req.URL.Path = "/api/v1/playbooks/pb-assign-1/assign"
 		rr := httptest.NewRecorder()
@@ -573,7 +573,7 @@ func TestHandleRootPlaybooks_Assign(t *testing.T) {
 	})
 
 	t.Run("missing playbook", func(t *testing.T) {
-		b, _ := json.Marshal(map[string]string{"client_id": "client-assign-1"})
+		b, _ := json.Marshal(map[string]string{"agent_id": "client-assign-1"})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/playbooks/no-playbook/assign", bytes.NewReader(b))
 		req.URL.Path = "/api/v1/playbooks/no-playbook/assign"
 		rr := httptest.NewRecorder()
@@ -587,7 +587,7 @@ func TestHandleRootPlaybooks_Assign(t *testing.T) {
 	t.Run("service missing", func(t *testing.T) {
 		envNoService := newTestEnv(t)
 		envNoService.Service = nil
-		b, _ := json.Marshal(map[string]string{"client_id": "client-assign-1"})
+		b, _ := json.Marshal(map[string]string{"agent_id": "client-assign-1"})
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/playbooks/pb-assign-1/assign", bytes.NewReader(b))
 		req.URL.Path = "/api/v1/playbooks/pb-assign-1/assign"
 		rr := httptest.NewRecorder()
@@ -660,120 +660,120 @@ func TestHandleRootPlaybooks_UpdateAndGetErrors(t *testing.T) {
 	})
 }
 
-func TestHandleRootClients_CRUDAndErrors(t *testing.T) {
+func TestHandleRootAgents_CRUDAndErrors(t *testing.T) {
 	env := newTestEnv(t)
 	now := time.Now()
 
-	if err := env.Store.SaveClient(&common.Client{
+	if err := env.Store.SaveAgent(&common.Agent{
 		ID:             "client-root-1",
 		Hostname:       "edge-root",
 		Platform:       common.PlatformLinux,
-		Status:         common.ClientStatusRegistered,
+		Status:         common.AgentStatusRegistered,
 		RegisteredAt:   now,
 		LastActivityAt: now,
 	}); err != nil {
-		t.Fatalf("SaveClient: %v", err)
+		t.Fatalf("SaveAgent: %v", err)
 	}
 
 	t.Run("list", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/clients", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/agents", nil)
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusOK {
 			t.Fatalf("status=%d", rr.Code)
 		}
-		var clients []*common.Client
-		_ = json.NewDecoder(rr.Body).Decode(&clients)
-		if len(clients) != 1 {
-			t.Fatalf("clients len=%d; want 1", len(clients))
+		var agents []*common.Agent
+		_ = json.NewDecoder(rr.Body).Decode(&agents)
+		if len(agents) != 1 {
+			t.Fatalf("agents len=%d; want 1", len(agents))
 		}
 	})
 
 	t.Run("get one", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/clients/client-root-1", nil)
-		req.URL.Path = "/api/v1/clients/client-root-1"
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/client-root-1", nil)
+		req.URL.Path = "/api/v1/agents/client-root-1"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusOK {
 			t.Fatalf("status=%d", rr.Code)
 		}
 	})
 
 	t.Run("get missing", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/clients/missing", nil)
-		req.URL.Path = "/api/v1/clients/missing"
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/missing", nil)
+		req.URL.Path = "/api/v1/agents/missing"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusNotFound {
 			t.Fatalf("status=%d; want 404", rr.Code)
 		}
 	})
 
 	t.Run("put missing id", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPut, "/api/v1/clients", bytes.NewBufferString(`{"status":"connected"}`))
-		req.URL.Path = "/api/v1/clients"
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/agents", bytes.NewBufferString(`{"status":"connected"}`))
+		req.URL.Path = "/api/v1/agents"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusBadRequest {
 			t.Fatalf("status=%d; want 400", rr.Code)
 		}
 	})
 
 	t.Run("put invalid json", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPut, "/api/v1/clients/client-root-1", bytes.NewBufferString("{"))
-		req.URL.Path = "/api/v1/clients/client-root-1"
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/agents/client-root-1", bytes.NewBufferString("{"))
+		req.URL.Path = "/api/v1/agents/client-root-1"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusBadRequest {
 			t.Fatalf("status=%d; want 400", rr.Code)
 		}
 	})
 
 	t.Run("put success", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPut, "/api/v1/clients/client-root-1", bytes.NewBufferString(`{"playbook_id":"pb-1","status":"deploying"}`))
-		req.URL.Path = "/api/v1/clients/client-root-1"
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/agents/client-root-1", bytes.NewBufferString(`{"playbook_id":"pb-1","status":"deploying"}`))
+		req.URL.Path = "/api/v1/agents/client-root-1"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusOK {
 			t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
 		}
-		c, ok := env.Store.GetClient("client-root-1")
+		c, ok := env.Store.GetAgent("client-root-1")
 		if !ok {
-			t.Fatal("client not found")
+			t.Fatal("agent not found")
 		}
-		if c.PlaybookID != "pb-1" || c.Status != common.ClientStatusDeploying {
+		if c.PlaybookID != "pb-1" || c.Status != common.AgentStatusDeploying {
 			t.Fatalf("unexpected update: playbook=%q status=%q", c.PlaybookID, c.Status)
 		}
 	})
 
 	t.Run("delete missing id", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodDelete, "/api/v1/clients", nil)
-		req.URL.Path = "/api/v1/clients"
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/agents", nil)
+		req.URL.Path = "/api/v1/agents"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusBadRequest {
 			t.Fatalf("status=%d; want 400", rr.Code)
 		}
 	})
 
 	t.Run("delete success", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodDelete, "/api/v1/clients/client-root-1", nil)
-		req.URL.Path = "/api/v1/clients/client-root-1"
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/agents/client-root-1", nil)
+		req.URL.Path = "/api/v1/agents/client-root-1"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusOK {
 			t.Fatalf("status=%d", rr.Code)
 		}
-		if _, ok := env.Store.GetClient("client-root-1"); ok {
-			t.Fatal("client should be deleted")
+		if _, ok := env.Store.GetAgent("client-root-1"); ok {
+			t.Fatal("agent should be deleted")
 		}
 	})
 
 	t.Run("method not allowed", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPatch, "/api/v1/clients", nil)
-		req.URL.Path = "/api/v1/clients"
+		req := httptest.NewRequest(http.MethodPatch, "/api/v1/agents", nil)
+		req.URL.Path = "/api/v1/agents"
 		rr := httptest.NewRecorder()
-		env.HandleRootClients(rr, req)
+		env.HandleRootAgents(rr, req)
 		if rr.Code != http.StatusMethodNotAllowed {
 			t.Fatalf("status=%d; want 405", rr.Code)
 		}
@@ -883,7 +883,7 @@ func TestHandleRootDeployments_ListGetAndNotFound(t *testing.T) {
 	now := time.Now()
 	_ = env.Store.SaveDeployment(&common.DeploymentState{
 		ID:         "dep-list-1",
-		ClientID:   "client-1",
+		AgentID:    "agent-1",
 		PlaybookID: "pb-1",
 		Status:     common.DeploymentStatusRunning,
 		StartedAt:  now,
@@ -1056,8 +1056,8 @@ func TestHandleArtifacts_ErrorPaths(t *testing.T) {
 
 func TestHandleArtifacts_AccessPolicy(t *testing.T) {
 	env := newTestEnv(t)
-	clientID, token := registerAgent(t, env, "client-1", "host-1")
-	_, otherToken := registerAgent(t, env, "client-2", "host-2")
+	agentID, token := registerAgent(t, env, "agent-1", "host-1")
+	_, otherToken := registerAgent(t, env, "agent-2", "host-2")
 
 	// 1. Upload Public Artifact
 	pubReq := httptest.NewRequest(http.MethodPost, "/artifacts?name=pub.bin&access_policy=public", bytes.NewBufferString("public content"))
@@ -1073,8 +1073,8 @@ func TestHandleArtifacts_AccessPolicy(t *testing.T) {
 	env.HandleArtifacts(authRR, authReq)
 	authArt := decode[common.Artifact](t, authRR)
 
-	// 3. Upload Restricted Artifact for client-1 (use the actual ULID assigned at registration)
-	restReq := httptest.NewRequest(http.MethodPost, "/artifacts?name=rest.bin&access_policy=restricted&allowed_clients="+clientID, bytes.NewBufferString("rest content"))
+	// 3. Upload Restricted Artifact for agent-1 (use the actual ULID assigned at registration)
+	restReq := httptest.NewRequest(http.MethodPost, "/artifacts?name=rest.bin&access_policy=restricted&allowed_agents="+agentID, bytes.NewBufferString("rest content"))
 	restReq.SetBasicAuth("root", env.RootPassword)
 	restRR := httptest.NewRecorder()
 	env.HandleArtifacts(restRR, restReq)
@@ -1108,7 +1108,7 @@ func TestHandleArtifacts_AccessPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("restricted download other client", func(t *testing.T) {
+	t.Run("restricted download other agent", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/artifacts/"+restArt.ID, nil)
 		req.Header.Set("Authorization", "Bearer "+otherToken)
 		rr := httptest.NewRecorder()
@@ -1118,7 +1118,7 @@ func TestHandleArtifacts_AccessPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("restricted download allowed client", func(t *testing.T) {
+	t.Run("restricted download allowed agent", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/artifacts/"+restArt.ID, nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rr := httptest.NewRecorder()
@@ -1141,7 +1141,7 @@ func TestHandleArtifacts_AccessPolicy(t *testing.T) {
 
 func TestHandleArtifacts_ModifyPolicy(t *testing.T) {
 	env := newTestEnv(t)
-	_, token := registerAgent(t, env, "client-1", "host-1")
+	_, token := registerAgent(t, env, "agent-1", "host-1")
 
 	// 1. Upload Authenticated Artifact
 	req := httptest.NewRequest(http.MethodPost, "/artifacts?name=mod.bin&access_policy=authenticated", bytes.NewBufferString("content"))
@@ -1174,8 +1174,8 @@ func TestHandleArtifacts_ModifyPolicy(t *testing.T) {
 		t.Fatalf("after patch dl: status=%d; want 200", pubRR.Code)
 	}
 
-	// 5. Modify to Restricted for client-2
-	modReq2 := httptest.NewRequest(http.MethodPatch, "/artifacts/"+art.ID+"?access_policy=restricted&allowed_clients=client-2", nil)
+	// 5. Modify to Restricted for agent-2
+	modReq2 := httptest.NewRequest(http.MethodPatch, "/artifacts/"+art.ID+"?access_policy=restricted&allowed_agents=agent-2", nil)
 	modReq2.SetBasicAuth("root", env.RootPassword)
 	modRR2 := httptest.NewRecorder()
 	env.HandleArtifacts(modRR2, modReq2)
@@ -1183,19 +1183,19 @@ func TestHandleArtifacts_ModifyPolicy(t *testing.T) {
 		t.Fatalf("patch2 status=%d", modRR2.Code)
 	}
 
-	// 6. Verify client-1 (from token) cannot download it
+	// 6. Verify agent-1 (from token) cannot download it
 	c1Req := httptest.NewRequest(http.MethodGet, "/artifacts/"+art.ID, nil)
 	c1Req.Header.Set("Authorization", "Bearer "+token)
 	c1RR := httptest.NewRecorder()
 	env.HandleArtifacts(c1RR, c1Req)
 	if c1RR.Code != http.StatusForbidden {
-		t.Fatalf("restricted c1: status=%d; want 403", c1RR.Code)
+		t.Fatalf("restricted agent-1: status=%d; want 403", c1RR.Code)
 	}
 }
 
-// ── Cross-client security ─────────────────────────────────────────────────────
+// ── Cross-agent security ──────────────────────────────────────────────────────
 
-func TestCrossClientDeploymentForbidden(t *testing.T) {
+func TestCrossAgentDeploymentForbidden(t *testing.T) {
 	env := newTestEnv(t)
 	ownerID, _ := registerAgent(t, env, "SN-031", "host-31")
 	_, _ = registerAgent(t, env, "SN-032", "host-32")
@@ -1203,7 +1203,7 @@ func TestCrossClientDeploymentForbidden(t *testing.T) {
 	// Create a deployment owned by ownerID.
 	dep := &common.DeploymentState{
 		ID:        "dep-owned",
-		ClientID:  ownerID,
+		AgentID:   ownerID,
 		Status:    common.DeploymentStatusRunning,
 		StartedAt: time.Now(),
 		UpdatedAt: time.Now(),

--- a/internal/server/handlers/ui/assets/style.css
+++ b/internal/server/handlers/ui/assets/style.css
@@ -42,9 +42,9 @@ nav a.active{color:#e6edf3;border-bottom-color:#f78166}
 .list-artifacts .list-head, .list-artifacts .list-row { display: grid; grid-template-columns: 1.4fr 1fr 0.8fr 1.1fr 1.2fr 46px; gap: 12px; align-items: center; padding: 10px 14px; }
 .list-playbooks .list-head, .list-playbooks .list-row { display: grid; grid-template-columns: 1.2fr 1.6fr .6fr .6fr .9fr 46px; gap: 12px; align-items: center; padding: 10px 12px; }
 .list-secrets .list-head, .list-secrets .list-row { display: grid; grid-template-columns: 1fr 1.8fr 46px; gap: 12px; align-items: center; padding: 10px 14px; }
-.list-clients .list-head, .list-clients .list-row { display: grid; grid-template-columns: 1.2fr 1fr 1.1fr .8fr .8fr 1fr 46px; gap: 10px; align-items: center; padding: 10px 12px; }
-.list-clients .list-head { position: sticky; top: 0; z-index: 2; }
-.list-clients .cell-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.list-agents .list-head, .list-agents .list-row { display: grid; grid-template-columns: 1.2fr 1fr 1.1fr .8fr .8fr 1fr 46px; gap: 10px; align-items: center; padding: 10px 12px; }
+.list-agents .list-head { position: sticky; top: 0; z-index: 2; }
+.list-agents .cell-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .card-top-right { display: flex; align-items: flex-start; gap: 8px; }
 .card-menu { position: relative; }
 .menu-btn { background: transparent; border: none; color: #8b949e; padding: 2px 7px; border-radius: 4px; cursor: pointer; font-size: 1.1rem; line-height: 1; }
@@ -77,10 +77,10 @@ nav a.active{color:#e6edf3;border-bottom-color:#f78166}
   .list-deployments .list-row{grid-template-columns:1fr;gap:6px}
   .log-head{display:none}
   .log-row{grid-template-columns:1fr;gap:4px}
-  .list-clients .list-row{grid-template-columns:1fr;gap:6px;padding:12px}
-  .list-clients .list-row > div{display:flex;justify-content:space-between;gap:12px}
-  .list-clients .cell-main{display:block}
-  .list-clients .cell-main .name{margin-bottom:2px}
+  .list-agents .list-row{grid-template-columns:1fr;gap:6px;padding:12px}
+  .list-agents .list-row > div{display:flex;justify-content:space-between;gap:12px}
+  .list-agents .cell-main{display:block}
+  .list-agents .cell-main .name{margin-bottom:2px}
   .mobile-label{display:inline;color:#8b949e;font-size:.75rem}
 }
 @media (min-width: 1101px){

--- a/internal/server/handlers/ui/templates/pages/agents.html
+++ b/internal/server/handlers/ui/templates/pages/agents.html
@@ -1,10 +1,10 @@
 {{template "layout" .}}
 {{define "scripts"}}
 <script>
-async function removeClient(id, hostname){
-  showConfirm('Remove Client','Remove "'+hostname+'"? This cannot be undone.',async function(){
+async function removeAgent(id, hostname){
+  showConfirm('Remove Agent','Remove "'+hostname+'"? This cannot be undone.',async function(){
     try {
-      var r=await fetch('/api/v1/clients/'+encodeURIComponent(id),{method:'DELETE',headers:headersAuth()});
+      var r=await fetch('/api/v1/agents/'+encodeURIComponent(id),{method:'DELETE',headers:headersAuth()});
       if(r.status===401){showLogin('Session expired — sign in again');return;}
       if(r.ok) refreshTable();
     } catch(e){}
@@ -18,14 +18,14 @@ async function removeClient(id, hostname){
     <span id="counts-bar">Loading…</span>
     <span class="spacer"></span>
     <div class="search-inline">
-      <input id="f-query" type="search" name="q" placeholder="Search clients…" autocomplete="off"
-             hx-get="/ui/partials/clients" hx-target="#table-root" hx-trigger="input changed delay:300ms, search">
+      <input id="f-query" type="search" name="q" placeholder="Search agents…" autocomplete="off"
+             hx-get="/ui/partials/agents" hx-target="#table-root" hx-trigger="input changed delay:300ms, search">
       <button class="btn-clear btn-muted" onclick="document.getElementById('f-query').value='';htmx.trigger(document.getElementById('f-query'),'search')" title="Clear">✕</button>
     </div>
-    <button hx-get="/ui/partials/clients" hx-target="#table-root" hx-include="#f-query">Refresh</button>
+    <button hx-get="/ui/partials/agents" hx-target="#table-root" hx-include="#f-query">Refresh</button>
   </div>
   <div id="table-root"
-       hx-get="/ui/partials/clients"
+       hx-get="/ui/partials/agents"
        hx-trigger="load, every 10s"
        hx-swap="innerHTML">
     <div class="spinner"></div>

--- a/internal/server/handlers/ui/templates/pages/artifacts.html
+++ b/internal/server/handlers/ui/templates/pages/artifacts.html
@@ -33,14 +33,14 @@
       <div class="form-group">
         <label>Access Policy</label>
         <select id="artifact-policy" onchange="toggleRestrictedUI()">
-          <option value="authenticated">Authenticated (all clients)</option>
+          <option value="authenticated">Authenticated (all agents)</option>
           <option value="public">Public (unauthenticated)</option>
-          <option value="restricted">Restricted (selected clients only)</option>
+          <option value="restricted">Restricted (selected agents only)</option>
         </select>
       </div>
       <div id="restricted-ui" class="form-group" style="display:none">
-        <label>Allowed Client IDs (comma separated)</label>
-        <input id="artifact-clients" type="text" placeholder="client-uuid-1, client-uuid-2">
+        <label>Allowed Agent IDs (comma separated)</label>
+        <input id="artifact-agents" type="text" placeholder="agent-uuid-1, agent-uuid-2">
       </div>
     </div>
     <div class="modal-err" id="upload-modal-err"></div>
@@ -70,8 +70,8 @@
         </select>
       </div>
       <div id="modify-restricted-group" class="form-group" style="display:none">
-        <label>Allowed Client IDs (comma separated)</label>
-        <input type="text" id="modify-allowed-clients" placeholder="client-1, client-2">
+        <label>Allowed Agent IDs (comma separated)</label>
+        <input type="text" id="modify-allowed-agents" placeholder="agent-1, agent-2">
       </div>
       <div id="modify-error" class="modal-err"></div>
     </div>
@@ -93,7 +93,7 @@ function showUploadModal(){
   document.getElementById('artifact-name').value='';
   document.getElementById('artifact-file').value='';
   document.getElementById('artifact-policy').value='authenticated';
-  document.getElementById('artifact-clients').value='';
+  document.getElementById('artifact-agents').value='';
   document.getElementById('restricted-ui').style.display='none';
   document.getElementById('upload-modal-err').textContent='';
   showModal('modal-upload');
@@ -106,11 +106,11 @@ async function uploadArtifact(){
   var file=fileInput.files[0];
   var name=document.getElementById('artifact-name').value.trim();
   var policy=document.getElementById('artifact-policy').value;
-  var clients=document.getElementById('artifact-clients').value.trim();
+  var agents=document.getElementById('artifact-agents').value.trim();
   var params='?filename='+encodeURIComponent(file.name);
   if(name) params+='&name='+encodeURIComponent(name);
   params+='&access_policy='+encodeURIComponent(policy);
-  if(policy==='restricted'&&clients) params+='&allowed_clients='+encodeURIComponent(clients);
+  if(policy==='restricted'&&agents) params+='&allowed_agents='+encodeURIComponent(agents);
   try {
     var r=await fetch('/artifacts'+params,{method:'POST',headers:headersAuth(),body:file});
     if(r.status===401){showLogin('Session expired — sign in again');return;}
@@ -120,11 +120,11 @@ async function uploadArtifact(){
   } catch(e){errEl.textContent='Network error: '+e.message;}
 }
 
-function modifyPolicy(id,name,policy,allowedClients){
+function modifyPolicy(id,name,policy,allowedAgents){
   document.getElementById('modify-art-name').innerText=name;
   document.getElementById('modify-art-id').innerText=id;
   document.getElementById('modify-policy').value=policy;
-  document.getElementById('modify-allowed-clients').value=allowedClients||'';
+  document.getElementById('modify-allowed-agents').value=allowedAgents||'';
   toggleModifyRestricted();
   document.getElementById('modify-error').innerText='';
   showModal('modal-modify');
@@ -134,10 +134,10 @@ function modifyPolicy(id,name,policy,allowedClients){
 async function savePolicy(){
   var id=window.currentModifyId;
   var policy=document.getElementById('modify-policy').value;
-  var clients=document.getElementById('modify-allowed-clients').value;
+  var agents=document.getElementById('modify-allowed-agents').value;
   var err=document.getElementById('modify-error');
   try {
-    var url='/artifacts/'+id+'?access_policy='+encodeURIComponent(policy)+'&allowed_clients='+encodeURIComponent(clients);
+    var url='/artifacts/'+id+'?access_policy='+encodeURIComponent(policy)+'&allowed_agents='+encodeURIComponent(agents);
     var res=await fetch(url,{method:'PATCH',headers:headersAuth()});
     if(!res.ok){var d=await res.json();throw new Error(d.error||'Failed to update policy');}
     closeModal('modal-modify');

--- a/internal/server/handlers/ui/templates/pages/home.html
+++ b/internal/server/handlers/ui/templates/pages/home.html
@@ -3,7 +3,7 @@
 <div class="container">
   <div class="welcome-section">
     <h2>Welcome to Kompakt</h2>
-    <p>Deployment automation for your infrastructure. Manage clients, playbooks, and deployments with ease.</p>
+    <p>Deployment automation for your infrastructure. Manage agents, playbooks, and deployments with ease.</p>
   </div>
   <div id="stats-root"
        hx-get="/ui/partials/home-stats"

--- a/internal/server/handlers/ui/templates/pages/playbooks.html
+++ b/internal/server/handlers/ui/templates/pages/playbooks.html
@@ -43,7 +43,7 @@
     <div class="modal-head"><h2>Assign Playbook</h2></div>
     <div class="modal-body">
       <div class="form-group"><label>Playbook</label><input id="assign-pb-name" type="text" readonly></div>
-      <div class="form-group"><label>Client</label><select id="assign-client"></select></div>
+      <div class="form-group"><label>Agent</label><select id="assign-agent"></select></div>
     </div>
     <div class="modal-err" id="assign-modal-err"></div>
     <div class="modal-actions">
@@ -116,22 +116,22 @@ function openAssign(id,name){
   _assigningID=id;
   document.getElementById('assign-pb-name').value=name+' ('+id+')';
   document.getElementById('assign-modal-err').textContent='';
-  // Fetch fresh client list
-  fetch('/api/v1/clients',{headers:headersAuth()}).then(function(r){return r.json();}).then(function(clients){
-    var sel=document.getElementById('assign-client');
-    sel.innerHTML=(clients||[]).map(function(c){return '<option value="'+esc(c.id)+'">'+esc((c.hostname||c.id)+' – '+(c.status||'unknown'))+'</option>';}).join('');
-    document.getElementById('assign-modal-err').textContent=clients.length?'':'No clients available';
-  }).catch(function(){document.getElementById('assign-modal-err').textContent='Failed to load clients';});
+  // Fetch fresh agent list
+  fetch('/api/v1/agents',{headers:headersAuth()}).then(function(r){return r.json();}).then(function(agents){
+    var sel=document.getElementById('assign-agent');
+    sel.innerHTML=(agents||[]).map(function(a){return '<option value="'+esc(a.id)+'">'+esc((a.hostname||a.id)+' – '+(a.status||'unknown'))+'</option>';}).join('');
+    document.getElementById('assign-modal-err').textContent=agents.length?'':'No agents available';
+  }).catch(function(){document.getElementById('assign-modal-err').textContent='Failed to load agents';});
   document.getElementById('assign-modal-bg').classList.add('show');
 }
 function closeAssignModal(){document.getElementById('assign-modal-bg').classList.remove('show');}
 
 async function confirmAssign(){
   var errEl=document.getElementById('assign-modal-err');
-  var clientID=document.getElementById('assign-client').value;
-  if(!clientID){errEl.textContent='Select a client';return;}
+  var agentID=document.getElementById('assign-agent').value;
+  if(!agentID){errEl.textContent='Select an agent';return;}
   try {
-    var r=await fetch('/api/v1/playbooks/'+encodeURIComponent(_assigningID)+'/assign',{method:'POST',headers:headersJSON(),body:JSON.stringify({client_id:clientID})});
+    var r=await fetch('/api/v1/playbooks/'+encodeURIComponent(_assigningID)+'/assign',{method:'POST',headers:headersJSON(),body:JSON.stringify({agent_id:agentID})});
     if(r.status===401){closeAssignModal();showLogin('Session expired — sign in again');return;}
     if(!r.ok){var msg='Assign failed ('+r.status+')';try{var d=await r.json();if(d.error)msg=d.error;}catch(_){}errEl.textContent=msg;return;}
     closeAssignModal();

--- a/internal/server/handlers/ui/templates/partials/agents-table.html
+++ b/internal/server/handlers/ui/templates/partials/agents-table.html
@@ -1,14 +1,14 @@
 {{if not .Rows}}
-<div class="empty">{{if .Query}}No clients match your search.{{else}}No clients registered yet.{{end}}</div>
+<div class="empty">{{if .Query}}No agents match your search.{{else}}No agents registered yet.{{end}}</div>
 {{else}}
 <script>
   var el=document.getElementById('counts-bar');
   if(el) el.textContent='Shown: {{.Shown}} / {{.Total}} · Connected: {{.Connected}} · Deploying: {{.Deploying}}';
 </script>
 <div class="table-wrap">
-<div class="list list-clients">
+<div class="list list-agents">
   <div class="list-head">
-    <div>Client</div><div>OS</div><div>Model</div><div>IP</div><div>Status</div><div>Last Activity</div><div></div>
+    <div>Agent</div><div>OS</div><div>Model</div><div>IP</div><div>Status</div><div>Last Activity</div><div></div>
   </div>
   {{range .Rows}}
   <div class="list-row">
@@ -33,7 +33,7 @@
     <div class="card-top-right"><div class="card-menu">
       <button class="menu-btn" title="Actions">⋮</button>
       <div class="menu-dropdown">
-        <button class="menu-item" onclick="removeClient('{{.ID}}','{{or .Hostname .ID}}')"><i class="m-icon" data-lucide="trash-2"></i> Remove Client</button>
+        <button class="menu-item" onclick="removeAgent('{{.ID}}','{{or .Hostname .ID}}')"><i class="m-icon" data-lucide="trash-2"></i> Remove Agent</button>
       </div>
     </div></div>
   </div>
@@ -48,14 +48,14 @@
 {{if gt .TotalPages 1}}
 <div class="pagination">
   {{if gt .Page 1}}
-  <button hx-get="/ui/partials/clients?page={{sub .Page 1}}&q={{.Query}}" hx-target="#table-root">‹ Prev</button>
+  <button hx-get="/ui/partials/agents?page={{sub .Page 1}}&q={{.Query}}" hx-target="#table-root">‹ Prev</button>
   {{end}}
   {{range seq .TotalPages}}
   <button {{if eq . $.Page}}class="active"{{end}}
-          hx-get="/ui/partials/clients?page={{.}}&q={{$.Query}}" hx-target="#table-root">{{.}}</button>
+          hx-get="/ui/partials/agents?page={{.}}&q={{$.Query}}" hx-target="#table-root">{{.}}</button>
   {{end}}
   {{if lt .Page .TotalPages}}
-  <button hx-get="/ui/partials/clients?page={{add .Page 1}}&q={{.Query}}" hx-target="#table-root">Next ›</button>
+  <button hx-get="/ui/partials/agents?page={{add .Page 1}}&q={{.Query}}" hx-target="#table-root">Next ›</button>
   {{end}}
 </div>
 {{end}}

--- a/internal/server/handlers/ui/templates/partials/artifacts-table.html
+++ b/internal/server/handlers/ui/templates/partials/artifacts-table.html
@@ -16,13 +16,13 @@
     </div>
     <div class="mono">{{.Filename}}</div>
     <div>{{formatSize .Size}}</div>
-    <div><span class="badge {{policyClass (print .AccessPolicy)}}" title="{{if .AllowedClients}}{{range .AllowedClients}}{{.}} {{end}}{{end}}">{{policyLabel (print .AccessPolicy)}}</span></div>
+    <div><span class="badge {{policyClass (print .AccessPolicy)}}" title="{{if .AllowedAgents}}{{range .AllowedAgents}}{{.}} {{end}}{{end}}">{{policyLabel (print .AccessPolicy)}}</span></div>
     <div>{{formatTime .UploadedAt}}</div>
     <div class="card-top-right"><div class="card-menu">
       <button class="menu-btn" title="Actions">⋮</button>
       <div class="menu-dropdown">
         <button class="menu-item" onclick="downloadArtifact('{{.ID}}','{{.Filename}}')"><i class="m-icon" data-lucide="download"></i> Download</button>
-        <button class="menu-item" onclick="modifyPolicy('{{.ID}}','{{.Name}}','{{.AccessPolicy}}','{{range .AllowedClients}}{{.}},{{end}}')"><i class="m-icon" data-lucide="shield"></i> Modify Policy</button>
+        <button class="menu-item" onclick="modifyPolicy('{{.ID}}','{{.Name}}','{{.AccessPolicy}}','{{range .AllowedAgents}}{{.}},{{end}}')"><i class="m-icon" data-lucide="shield"></i> Modify Policy</button>
         <button class="menu-item" onclick="removeArtifact('{{.ID}}')"><i class="m-icon" data-lucide="trash-2"></i> Remove</button>
       </div>
     </div></div>

--- a/internal/server/handlers/ui/templates/partials/home-stats.html
+++ b/internal/server/handlers/ui/templates/partials/home-stats.html
@@ -1,7 +1,7 @@
 <div class="dashboard-grid">
-  <a href="/ui/clients" class="stat-card">
-    <div class="stat-header"><i data-lucide="monitor" style="width:24px;height:24px;color:#58a6ff"></i><span>Connected Clients</span></div>
-    <div class="stat-value">{{.Clients}}</div>
+  <a href="/ui/agents" class="stat-card">
+    <div class="stat-header"><i data-lucide="monitor" style="width:24px;height:24px;color:#58a6ff"></i><span>Connected Agents</span></div>
+    <div class="stat-value">{{.Agents}}</div>
     <div class="stat-label">Active nodes in your fleet</div>
   </a>
   <a href="/ui/playbooks" class="stat-card">

--- a/internal/server/handlers/ui_templates.go
+++ b/internal/server/handlers/ui_templates.go
@@ -25,7 +25,7 @@ type navItem struct {
 func buildNav(active string) []navItem {
 	return []navItem{
 		{"Home", "/ui", active == "Home"},
-		{"Clients", "/ui/clients", active == "Clients"},
+		{"Agents", "/ui/agents", active == "Agents"},
 		{"Secrets", "/ui/secrets", active == "Secrets"},
 		{"Playbooks", "/ui/playbooks", active == "Playbooks"},
 		{"Deployments", "/ui/deployments", active == "Deployments"},
@@ -48,14 +48,14 @@ func newPage(title, active, search string) pageData {
 // ── Partial data types ────────────────────────────────────────────────────────
 
 type homeStatsData struct {
-	Clients     int
+	Agents      int
 	Playbooks   int
 	Deployments int
 	Artifacts   int
 }
 
-type clientsTableData struct {
-	Rows        []clientRow
+type agentsTableData struct {
+	Rows        []agentRow
 	Query       string
 	Page        int
 	TotalPages  int
@@ -65,8 +65,8 @@ type clientsTableData struct {
 	Deploying   int
 }
 
-type clientRow struct {
-	*common.Client
+type agentRow struct {
+	*common.Agent
 	DeployStep string
 	StatusStr  string
 }
@@ -89,7 +89,7 @@ type deploymentsTableData struct {
 
 type playbooksTableData struct {
 	Rows       []playbookRow
-	Clients    []*common.Client
+	Agents     []*common.Agent
 	Query      string
 	Page       int
 	TotalPages int
@@ -263,7 +263,7 @@ func (e *Handler) HandleHomeUI(w http.ResponseWriter, r *http.Request) {
 
 func (e *Handler) HandleAgentsUI(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
-	renderPage(w, "clients", newPage("Clients", "Clients", q))
+	renderPage(w, "agents", newPage("Agents", "Agents", q))
 }
 
 func (e *Handler) HandleArtifactsUI(w http.ResponseWriter, r *http.Request) {
@@ -285,9 +285,9 @@ func (e *Handler) HandleSecretsUI(w http.ResponseWriter, r *http.Request) {
 // ── Partial handlers (all behind RequireRootAuth) ─────────────────────────────
 
 func (e *Handler) HandlePartialHomeStats(w http.ResponseWriter, r *http.Request) {
-	clients, deployments := e.Store.ListClients(), e.Store.ListDeployments()
+	agents, deployments := e.Store.ListAgents(), e.Store.ListDeployments()
 	if e.Service != nil {
-		clients, deployments = e.Service.StatusSnapshot()
+		agents, deployments = e.Service.StatusSnapshot()
 	}
 	running := 0
 	for _, d := range deployments {
@@ -296,66 +296,66 @@ func (e *Handler) HandlePartialHomeStats(w http.ResponseWriter, r *http.Request)
 		}
 	}
 	renderPartialTemplate(w, "home-stats", homeStatsData{
-		Clients:     len(clients),
+		Agents:      len(agents),
 		Playbooks:   len(e.Store.ListPlaybooks()),
 		Deployments: running,
 		Artifacts:   len(e.Store.ListArtifacts()),
 	})
 }
 
-func (e *Handler) HandlePartialClients(w http.ResponseWriter, r *http.Request) {
+func (e *Handler) HandlePartialAgents(w http.ResponseWriter, r *http.Request) {
 	q := strings.ToLower(r.URL.Query().Get("q"))
 	page := pageParam(r)
 
-	clients, deployments := e.Store.ListClients(), e.Store.ListDeployments()
+	agents, deployments := e.Store.ListAgents(), e.Store.ListDeployments()
 	if e.Service != nil {
-		clients, deployments = e.Service.StatusSnapshot()
+		agents, deployments = e.Service.StatusSnapshot()
 	}
-	depByClient := make(map[string]*common.DeploymentState, len(deployments))
+	depByAgent := make(map[string]*common.DeploymentState, len(deployments))
 	for _, d := range deployments {
-		depByClient[d.ClientID] = d
+		depByAgent[d.AgentID] = d
 	}
 
 	// Filter
-	var filtered []*common.Client
-	for _, c := range clients {
+	var filtered []*common.Agent
+	for _, a := range agents {
 		if q != "" {
-			hay := strings.ToLower((c.Hostname + " " + c.OS + " " + c.Vendor + " " + c.Model + " " + c.IPAddress + " " + string(c.ID)))
+			hay := strings.ToLower((a.Hostname + " " + a.OS + " " + a.Vendor + " " + a.Model + " " + a.IPAddress + " " + string(a.ID)))
 			if !strings.Contains(hay, q) {
 				continue
 			}
 		}
-		filtered = append(filtered, c)
+		filtered = append(filtered, a)
 	}
 
 	connected, deploying := 0, 0
-	for _, c := range filtered {
-		if c.Status == common.ClientStatusConnected {
+	for _, a := range filtered {
+		if a.Status == common.AgentStatusConnected {
 			connected++
 		}
-		if c.Status == common.ClientStatusDeploying {
+		if a.Status == common.AgentStatusDeploying {
 			deploying++
 		}
 	}
 
 	paged := paginate(filtered, page, uiPageSize)
-	rows := make([]clientRow, len(paged))
-	for i, c := range paged {
+	rows := make([]agentRow, len(paged))
+	for i, a := range paged {
 		step := "-"
-		status := string(c.Status)
-		if dep, ok := depByClient[c.ID]; ok {
+		status := string(a.Status)
+		if dep, ok := depByAgent[a.ID]; ok {
 			step = "#" + strconv.Itoa(dep.ResumeStepIndex)
 			status = string(dep.Status)
 		}
-		rows[i] = clientRow{Client: c, DeployStep: step, StatusStr: status}
+		rows[i] = agentRow{Agent: a, DeployStep: step, StatusStr: status}
 	}
 
-	renderPartialTemplate(w, "clients-table", clientsTableData{
+	renderPartialTemplate(w, "agents-table", agentsTableData{
 		Rows:       rows,
 		Query:      r.URL.Query().Get("q"),
 		Page:       page,
 		TotalPages: totalPages(len(filtered), uiPageSize),
-		Total:      len(clients),
+		Total:      len(agents),
 		Shown:      len(filtered),
 		Connected:  connected,
 		Deploying:  deploying,
@@ -395,7 +395,7 @@ func (e *Handler) HandlePartialDeployments(w http.ResponseWriter, r *http.Reques
 	var filtered []*common.DeploymentState
 	for _, d := range all {
 		if q != "" {
-			hay := strings.ToLower(d.ID + " " + d.ClientID + " " + d.PlaybookID + " " + d.Hostname + " " + d.PlaybookName)
+			hay := strings.ToLower(d.ID + " " + d.AgentID + " " + d.PlaybookID + " " + d.Hostname + " " + d.PlaybookName)
 			if !strings.Contains(hay, q) {
 				continue
 			}
@@ -424,7 +424,7 @@ func (e *Handler) HandlePartialPlaybooks(w http.ResponseWriter, r *http.Request)
 	page := pageParam(r)
 
 	all := e.Store.ListPlaybooks()
-	clients := e.Store.ListClients()
+	agents := e.Store.ListAgents()
 
 	var filtered []playbookRow
 	for _, pb := range all {
@@ -446,7 +446,7 @@ func (e *Handler) HandlePartialPlaybooks(w http.ResponseWriter, r *http.Request)
 
 	renderPartialTemplate(w, "playbooks-table", playbooksTableData{
 		Rows:       paginate(filtered, page, uiPageSize),
-		Clients:    clients,
+		Agents:     agents,
 		Query:      r.URL.Query().Get("q"),
 		Page:       page,
 		TotalPages: totalPages(len(filtered), uiPageSize),

--- a/internal/server/handlers/ws.go
+++ b/internal/server/handlers/ws.go
@@ -19,17 +19,17 @@ var wsUpgrader = websocket.Upgrader{
 
 // HandleAgentWS upgrades GET /api/v1/ws to a WebSocket connection.
 // Authentication uses the JWT bearer token passed as ?token=<jwt> query param
-// (WebSocket clients cannot set arbitrary headers during the handshake in all
+// (WebSocket agents cannot set arbitrary headers during the handshake in all
 // environments, so the query param fallback is supported here).
 func (e *Handler) HandleAgentWS(w http.ResponseWriter, r *http.Request) {
-	clientID, err := e.clientIDFromToken(r)
+	agentID, err := e.agentIDFromToken(r)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, err.Error())
 		return
 	}
-	client, ok := e.Store.GetClient(clientID)
+	agent, ok := e.Store.GetAgent(agentID)
 	if !ok {
-		writeError(w, http.StatusNotFound, "client not found")
+		writeError(w, http.StatusNotFound, "agent not found")
 		return
 	}
 
@@ -38,28 +38,28 @@ func (e *Handler) HandleAgentWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	conn := newWSConn(clientID, ws)
+	conn := newWSConn(agentID, ws)
 	e.Hub.register(conn)
 
-	client.Status = common.ClientStatusConnected
-	client.IPAddress = requestIP(r)
-	client.LastActivityAt = time.Now()
-	_ = e.Store.SaveClient(client)
+	agent.Status = common.AgentStatusConnected
+	agent.IPAddress = requestIP(r)
+	agent.LastActivityAt = time.Now()
+	_ = e.Store.SaveAgent(agent)
 
 	defer func() {
-		e.Hub.unregister(clientID)
-		if c, ok := e.Store.GetClient(clientID); ok {
-			if c.Status == common.ClientStatusConnected {
-				c.Status = common.ClientStatusOffline
+		e.Hub.unregister(agentID)
+		if a, ok := e.Store.GetAgent(agentID); ok {
+			if a.Status == common.AgentStatusConnected {
+				a.Status = common.AgentStatusOffline
 			}
-			_ = e.Store.SaveClient(c)
+			_ = e.Store.SaveAgent(a)
 		}
 		_ = ws.Close()
 	}()
 
 	// Push playbook immediately if one is assigned.
 	if e.Service != nil {
-		e.Service.PushPlaybookIfAssigned(clientID, false)
+		e.Service.PushPlaybookIfAssigned(agentID, false)
 	}
 
 	// Read loop.
@@ -70,7 +70,7 @@ func (e *Handler) HandleAgentWS(w http.ResponseWriter, r *http.Request) {
 		return ws.SetReadDeadline(time.Now().Add(90 * time.Second))
 	})
 
-	// Send pings every 30 s so the client resets its read deadline and replies
+	// Send pings every 30 s so the agent resets its read deadline and replies
 	// with a pong that resets ours.  WriteControl is safe to call concurrently.
 	pingDone := make(chan struct{})
 	defer close(pingDone)
@@ -97,18 +97,18 @@ func (e *Handler) HandleAgentWS(w http.ResponseWriter, r *http.Request) {
 		if err := ws.SetReadDeadline(time.Now().Add(90 * time.Second)); err != nil {
 			return
 		}
-		e.handleWSMessage(clientID, data)
+		e.handleWSMessage(agentID, data)
 	}
 }
 
-// handleWSMessage dispatches an inbound WebSocket message from a client.
-func (e *Handler) handleWSMessage(clientID string, data []byte) {
+// handleWSMessage dispatches an inbound WebSocket message from an agent.
+func (e *Handler) handleWSMessage(agentID string, data []byte) {
 	var envelope struct {
 		Type common.WSMessageType `json:"type"`
 		Data json.RawMessage      `json:"data"`
 	}
 	if err := json.Unmarshal(data, &envelope); err != nil {
-		slog.Error("failed to parse websocket envelope", "client_id", clientID, "err", err)
+		slog.Error("failed to parse websocket envelope", "agent_id", agentID, "err", err)
 		return
 	}
 
@@ -116,7 +116,7 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 	case common.WSMsgLog:
 		var d common.WSLogData
 		if err := json.Unmarshal(envelope.Data, &d); err != nil {
-			slog.Error("failed to parse log message", "client_id", clientID, "err", err)
+			slog.Error("failed to parse log message", "agent_id", agentID, "err", err)
 			return
 		}
 		entry := &common.LogEntry{
@@ -132,7 +132,7 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 	case common.WSMsgStepStart:
 		var d common.WSStepData
 		if err := json.Unmarshal(envelope.Data, &d); err != nil {
-			slog.Error("failed to parse step-start message", "client_id", clientID, "err", err)
+			slog.Error("failed to parse step-start message", "agent_id", agentID, "err", err)
 			return
 		}
 		stepName := d.StepName
@@ -151,7 +151,7 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 	case common.WSMsgStepComplete:
 		var d common.WSStepData
 		if err := json.Unmarshal(envelope.Data, &d); err != nil {
-			slog.Error("failed to parse step-complete message", "client_id", clientID, "err", err)
+			slog.Error("failed to parse step-complete message", "agent_id", agentID, "err", err)
 			return
 		}
 		stepName := d.StepName
@@ -169,7 +169,7 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 	case common.WSMsgStepFailed:
 		var d common.WSStepData
 		if err := json.Unmarshal(envelope.Data, &d); err != nil {
-			slog.Error("failed to parse step-failed message", "client_id", clientID, "err", err)
+			slog.Error("failed to parse step-failed message", "agent_id", agentID, "err", err)
 			return
 		}
 		e.updateDeploy(d.DeploymentID, func(dep *common.DeploymentState) {
@@ -180,7 +180,7 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 	case common.WSMsgReboot:
 		var d common.WSRebootData
 		if err := json.Unmarshal(envelope.Data, &d); err != nil {
-			slog.Error("failed to parse reboot message", "client_id", clientID, "err", err)
+			slog.Error("failed to parse reboot message", "agent_id", agentID, "err", err)
 			return
 		}
 		e.updateDeploy(d.DeploymentID, func(dep *common.DeploymentState) {
@@ -191,7 +191,7 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 	case common.WSMsgDeployDone:
 		var d common.WSStepData
 		if err := json.Unmarshal(envelope.Data, &d); err != nil {
-			slog.Error("failed to parse deploy-done message", "client_id", clientID, "err", err)
+			slog.Error("failed to parse deploy-done message", "agent_id", agentID, "err", err)
 			return
 		}
 		if e.Service != nil {
@@ -204,15 +204,15 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 			dep.Status = common.DeploymentStatusDone
 			dep.FinishedAt = &now
 		})
-		if c, ok := e.Store.GetClient(clientID); ok {
-			c.Status = common.ClientStatusDone
-			_ = e.Store.SaveClient(c)
+		if a, ok := e.Store.GetAgent(agentID); ok {
+			a.Status = common.AgentStatusDone
+			_ = e.Store.SaveAgent(a)
 		}
 
 	case common.WSMsgDeployFailed:
 		var d common.WSStepData
 		if err := json.Unmarshal(envelope.Data, &d); err != nil {
-			slog.Error("failed to parse deploy-failed message", "client_id", clientID, "err", err)
+			slog.Error("failed to parse deploy-failed message", "agent_id", agentID, "err", err)
 			return
 		}
 		playbookName := "playbook"
@@ -232,9 +232,9 @@ func (e *Handler) handleWSMessage(clientID string, data []byte) {
 			dep.ErrorDetail = d.Error
 			dep.FinishedAt = &now
 		})
-		if c, ok := e.Store.GetClient(clientID); ok {
-			c.Status = common.ClientStatusFailed
-			_ = e.Store.SaveClient(c)
+		if a, ok := e.Store.GetAgent(agentID); ok {
+			a.Status = common.AgentStatusFailed
+			_ = e.Store.SaveAgent(a)
 		}
 
 	case common.WSMsgPong:

--- a/internal/server/handlers/ws_internal_test.go
+++ b/internal/server/handlers/ws_internal_test.go
@@ -18,28 +18,28 @@ func newConnectTestEnv(t *testing.T) *Handler {
 	return &Handler{Store: st, Hub: NewHub()}
 }
 
-func saveClient(t *testing.T, e *Handler, id string) {
+func saveAgent(t *testing.T, e *Handler, id string) {
 	t.Helper()
 	now := time.Now()
-	err := e.Store.SaveClient(&common.Client{
+	err := e.Store.SaveAgent(&common.Agent{
 		ID:             id,
 		Hostname:       id,
 		Platform:       common.PlatformLinux,
-		Status:         common.ClientStatusConnected,
+		Status:         common.AgentStatusConnected,
 		RegisteredAt:   now,
 		LastActivityAt: now,
 	})
 	if err != nil {
-		t.Fatalf("SaveClient: %v", err)
+		t.Fatalf("SaveAgent: %v", err)
 	}
 }
 
-func saveDeployment(t *testing.T, e *Handler, depID, clientID string, status common.DeploymentStatus) {
+func saveDeployment(t *testing.T, e *Handler, depID, agentID string, status common.DeploymentStatus) {
 	t.Helper()
 	now := time.Now()
 	err := e.Store.SaveDeployment(&common.DeploymentState{
 		ID:         depID,
-		ClientID:   clientID,
+		AgentID:    agentID,
 		PlaybookID: "pb-1",
 		Status:     status,
 		StartedAt:  now,
@@ -50,18 +50,18 @@ func saveDeployment(t *testing.T, e *Handler, depID, clientID string, status com
 	}
 }
 
-func sendWS(t *testing.T, e *Handler, clientID string, msgType common.WSMessageType, data any) {
+func sendWS(t *testing.T, e *Handler, agentID string, msgType common.WSMessageType, data any) {
 	t.Helper()
 	b, err := json.Marshal(common.WSMessage{Type: msgType, Data: data})
 	if err != nil {
 		t.Fatalf("marshal message: %v", err)
 	}
-	e.handleWSMessage(clientID, b)
+	e.handleWSMessage(agentID, b)
 }
 
 func TestHandleWSMessage_LogAndLifecycleUpdates(t *testing.T) {
 	e := newConnectTestEnv(t)
-	saveClient(t, e, "c1")
+	saveAgent(t, e,"c1")
 	saveDeployment(t, e, "dep-1", "c1", common.DeploymentStatusPending)
 
 	sendWS(t, e, "c1", common.WSMsgLog, common.WSLogData{
@@ -113,15 +113,15 @@ func TestHandleWSMessage_LogAndLifecycleUpdates(t *testing.T) {
 	if dep.Status != common.DeploymentStatusDone || dep.FinishedAt == nil {
 		t.Fatalf("after deploy_done: status=%q finished_at_nil=%v", dep.Status, dep.FinishedAt == nil)
 	}
-	client, _ := e.Store.GetClient("c1")
-	if client.Status != common.ClientStatusDone {
-		t.Fatalf("client status = %q; want %q", client.Status, common.ClientStatusDone)
+	agent, _ := e.Store.GetAgent("c1")
+	if agent.Status != common.AgentStatusDone {
+		t.Fatalf("agent status = %q; want %q", agent.Status, common.AgentStatusDone)
 	}
 }
 
 func TestHandleWSMessage_UnknownType(t *testing.T) {
 	e := newConnectTestEnv(t)
-	saveClient(t, e, "c-unknown")
+	saveAgent(t, e,"c-unknown")
 	saveDeployment(t, e, "dep-unknown", "c-unknown", common.DeploymentStatusRunning)
 
 	before, _ := e.Store.GetDeployment("dep-unknown")
@@ -135,7 +135,7 @@ func TestHandleWSMessage_UnknownType(t *testing.T) {
 
 func TestHandleWSMessage_DeployFailedAndInvalidMessages(t *testing.T) {
 	e := newConnectTestEnv(t)
-	saveClient(t, e, "c2")
+	saveAgent(t, e,"c2")
 	saveDeployment(t, e, "dep-2", "c2", common.DeploymentStatusRunning)
 
 	before, _ := e.Store.GetDeployment("dep-2")
@@ -156,8 +156,8 @@ func TestHandleWSMessage_DeployFailedAndInvalidMessages(t *testing.T) {
 	if dep.Status != common.DeploymentStatusFailed || dep.ErrorDetail != "boom" || dep.FinishedAt == nil {
 		t.Fatalf("after deploy_failed: status=%q error=%q finished_at_nil=%v", dep.Status, dep.ErrorDetail, dep.FinishedAt == nil)
 	}
-	client, _ := e.Store.GetClient("c2")
-	if client.Status != common.ClientStatusFailed {
-		t.Fatalf("client status = %q; want %q", client.Status, common.ClientStatusFailed)
+	agent, _ := e.Store.GetAgent("c2")
+	if agent.Status != common.AgentStatusFailed {
+		t.Fatalf("agent status = %q; want %q", agent.Status, common.AgentStatusFailed)
 	}
 }

--- a/internal/server/ports/store.go
+++ b/internal/server/ports/store.go
@@ -7,14 +7,14 @@ import (
 
 // Store defines persistence capabilities used by handler/service layers.
 type Store interface {
-	SaveClient(c *common.Client) error
-	GetClient(id string) (*common.Client, bool)
-	ListClients() []*common.Client
-	DeleteClient(id string) error
+	SaveAgent(a *common.Agent) error
+	GetAgent(id string) (*common.Agent, bool)
+	ListAgents() []*common.Agent
+	DeleteAgent(id string) error
 
 	SaveDeployment(d *common.DeploymentState) error
 	GetDeployment(id string) (*common.DeploymentState, bool)
-	GetActiveDeploymentForClient(clientID string) (*common.DeploymentState, bool)
+	GetActiveDeploymentForAgent(agentID string) (*common.DeploymentState, bool)
 	ListDeployments() []*common.DeploymentState
 	DeleteDeployment(id string) error
 
@@ -38,11 +38,11 @@ type Store interface {
 
 	AppendLogs(entries []*common.LogEntry) error
 	GetLogsForDeployment(deploymentID string) []*common.LogEntry
-	GetLogsForClient(clientID string) []*common.LogEntry
+	GetLogsForAgent(agentID string) []*common.LogEntry
 }
 
 // Hub defines websocket coordination capabilities used by services.
 type Hub interface {
-	IsConnected(clientID string) bool
-	Send(clientID string, msg common.WSMessage) bool
+	IsConnected(agentID string) bool
+	Send(agentID string, msg common.WSMessage) bool
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,7 +40,7 @@ func NewServer(env *handlers.Handler) http.Handler {
 	mux.Handle("/ui/assets/", http.HandlerFunc(handlers.ServeUIAsset))
 	mux.Handle("/ui", http.HandlerFunc(env.HandleHomeUI))
 	mux.Handle("/ui/", http.HandlerFunc(env.HandleHomeUI))
-	mux.Handle("/ui/clients", http.HandlerFunc(env.HandleAgentsUI))
+	mux.Handle("/ui/agents", http.HandlerFunc(env.HandleAgentsUI))
 	mux.Handle("/ui/secrets", http.HandlerFunc(env.HandleSecretsUI))
 	mux.Handle("/ui/playbooks", http.HandlerFunc(env.HandlePlaybooksUI))
 	mux.Handle("/ui/deployments", http.HandlerFunc(env.HandleDeploymentsUI))
@@ -50,8 +50,8 @@ func NewServer(env *handlers.Handler) http.Handler {
 	mux.Handle("/api/v1/playbooks", root(http.HandlerFunc(env.HandleRootPlaybooks)))
 	mux.Handle("/api/v1/playbooks/", root(http.HandlerFunc(env.HandleRootPlaybooks)))
 
-	mux.Handle("/api/v1/clients", root(http.HandlerFunc(env.HandleRootClients)))
-	mux.Handle("/api/v1/clients/", root(http.HandlerFunc(env.HandleRootClients)))
+	mux.Handle("/api/v1/agents", root(http.HandlerFunc(env.HandleRootAgents)))
+	mux.Handle("/api/v1/agents/", root(http.HandlerFunc(env.HandleRootAgents)))
 
 	mux.Handle("/api/v1/deployments", root(http.HandlerFunc(env.HandleRootDeployments)))
 	mux.Handle("/api/v1/deployments/", root(http.HandlerFunc(env.HandleRootDeployments)))
@@ -66,7 +66,7 @@ func NewServer(env *handlers.Handler) http.Handler {
 
 	// ── HTMX partials (root auth required) ───────────────────────────────────
 	mux.Handle("/ui/partials/home-stats", root(http.HandlerFunc(env.HandlePartialHomeStats)))
-	mux.Handle("/ui/partials/clients", root(http.HandlerFunc(env.HandlePartialClients)))
+	mux.Handle("/ui/partials/agents", root(http.HandlerFunc(env.HandlePartialAgents)))
 	mux.Handle("/ui/partials/artifacts", root(http.HandlerFunc(env.HandlePartialArtifacts)))
 	mux.Handle("/ui/partials/deployments", root(http.HandlerFunc(env.HandlePartialDeployments)))
 	mux.Handle("/ui/partials/deployments/", root(http.HandlerFunc(env.HandlePartialDeploymentLogs)))
@@ -79,13 +79,13 @@ func NewServer(env *handlers.Handler) http.Handler {
 // dualAuth accepts requests authenticated with either an agent JWT Bearer
 // token or root HTTP Basic credentials.
 func dualAuth(env *handlers.Handler, next http.Handler) http.Handler {
-	clientMW := env.RequireAgentAuth(next)
+	agentMW := env.RequireAgentAuth(next)
 	adminMW := env.RequireRootAuth(next)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if _, _, ok := r.BasicAuth(); ok {
 			adminMW.ServeHTTP(w, r)
 		} else {
-			clientMW.ServeHTTP(w, r)
+			agentMW.ServeHTTP(w, r)
 		}
 	})
 }

--- a/internal/server/service/manager.go
+++ b/internal/server/service/manager.go
@@ -12,8 +12,8 @@ import (
 
 // Sentinel errors returned by service operations.
 var (
-	// ErrClientNotFound is returned when a client ID does not match any registered client.
-	ErrClientNotFound = errors.New("client not found")
+	// ErrAgentNotFound is returned when an agent ID does not match any registered agent.
+	ErrAgentNotFound = errors.New("agent not found")
 	// ErrPlaybookNotFound is returned when a playbook ID does not match any stored playbook.
 	ErrPlaybookNotFound = errors.New("playbook not found")
 )
@@ -25,38 +25,38 @@ type Manager struct {
 	ServerURL string
 }
 
-func (m *Manager) StatusSnapshot() ([]*common.Client, []*common.DeploymentState) {
-	return m.Store.ListClients(), m.Store.ListDeployments()
+func (m *Manager) StatusSnapshot() ([]*common.Agent, []*common.DeploymentState) {
+	return m.Store.ListAgents(), m.Store.ListDeployments()
 }
 
-func (m *Manager) AssignPlaybookToClient(playbookID, clientID string) error {
-	client, ok := m.Store.GetClient(clientID)
+func (m *Manager) AssignPlaybookToAgent(playbookID, agentID string) error {
+	agent, ok := m.Store.GetAgent(agentID)
 	if !ok {
-		return fmt.Errorf("assign playbook to client: %w", ErrClientNotFound)
+		return fmt.Errorf("assign playbook to agent: %w", ErrAgentNotFound)
 	}
 	if _, ok := m.Store.GetPlaybook(playbookID); !ok {
-		return fmt.Errorf("assign playbook to client: %w", ErrPlaybookNotFound)
+		return fmt.Errorf("assign playbook to agent: %w", ErrPlaybookNotFound)
 	}
-	client.PlaybookID = playbookID
-	if err := m.Store.SaveClient(client); err != nil {
-		return fmt.Errorf("failed to save client: %w", err)
+	agent.PlaybookID = playbookID
+	if err := m.Store.SaveAgent(agent); err != nil {
+		return fmt.Errorf("failed to save agent: %w", err)
 	}
-	if m.Hub.IsConnected(clientID) {
-		m.PushPlaybookIfAssigned(clientID, true)
+	if m.Hub.IsConnected(agentID) {
+		m.PushPlaybookIfAssigned(agentID, true)
 	}
 	return nil
 }
 
-// PushPlaybookIfAssigned sends an assigned playbook to a connected client.
+// PushPlaybookIfAssigned sends an assigned playbook to a connected agent.
 // If force is false, it skips if the latest deployment for this playbook is already Done.
-func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
-	client, ok := m.Store.GetClient(clientID)
-	if !ok || client.PlaybookID == "" {
+func (m *Manager) PushPlaybookIfAssigned(agentID string, force bool) {
+	agent, ok := m.Store.GetAgent(agentID)
+	if !ok || agent.PlaybookID == "" {
 		return
 	}
 
-	dep, hasDep := m.Store.GetActiveDeploymentForClient(clientID)
-	pb, ok := m.Store.GetPlaybook(client.PlaybookID)
+	dep, hasDep := m.Store.GetActiveDeploymentForAgent(agentID)
+	pb, ok := m.Store.GetPlaybook(agent.PlaybookID)
 	if !ok {
 		return
 	}
@@ -70,7 +70,7 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
 	//    - If Running/Rebooting: resume (ignore force).
 	//    - If Done/Failed: start new if force, otherwise skip.
 
-	isSamePlaybook := hasDep && dep.PlaybookID == client.PlaybookID
+	isSamePlaybook := hasDep && dep.PlaybookID == agent.PlaybookID
 
 	if isSamePlaybook && (dep.Status == common.DeploymentStatusPending ||
 		dep.Status == common.DeploymentStatusRunning ||
@@ -81,7 +81,7 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
 		dep.Status = common.DeploymentStatusRunning
 		dep.UpdatedAt = time.Now()
 		if err := m.Store.SaveDeployment(dep); err != nil {
-			slog.Error("failed to save deployment", "deployment_id", dep.ID, "client_id", clientID, "err", err)
+			slog.Error("failed to save deployment", "deployment_id", dep.ID, "agent_id", agentID, "err", err)
 			return
 		}
 	} else if !isSamePlaybook || force {
@@ -89,9 +89,9 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
 		deploymentID = common.NewID()
 		newDep := &common.DeploymentState{
 			ID:           deploymentID,
-			ClientID:     clientID,
-			Hostname:     client.Hostname,
-			PlaybookID:   client.PlaybookID,
+			AgentID:      agentID,
+			Hostname:     agent.Hostname,
+			PlaybookID:   agent.PlaybookID,
 			PlaybookName: pb.Name,
 			Status:          common.DeploymentStatusRunning,
 			ResumeStepIndex: 0,
@@ -102,7 +102,7 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
 			newDep.PlaybookName = pb.Playbook.Name
 		}
 		if err := m.Store.SaveDeployment(newDep); err != nil {
-			slog.Error("failed to save new deployment", "deployment_id", deploymentID, "client_id", clientID, "err", err)
+			slog.Error("failed to save new deployment", "deployment_id", deploymentID, "agent_id", agentID, "err", err)
 			return
 		}
 	} else {
@@ -112,9 +112,9 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
 		return
 	}
 
-	client.Status = common.ClientStatusDeploying
-	if err := m.Store.SaveClient(client); err != nil {
-		slog.Error("failed to update client status to deploying", "client_id", clientID, "err", err)
+	agent.Status = common.AgentStatusDeploying
+	if err := m.Store.SaveAgent(agent); err != nil {
+		slog.Error("failed to update agent status to deploying", "agent_id", agentID, "err", err)
 		return
 	}
 
@@ -125,7 +125,7 @@ func (m *Manager) PushPlaybookIfAssigned(clientID string, force bool) {
 	m.AppendDeploymentLog(deploymentID, "", 0, common.LogLevelInfo,
 		fmt.Sprintf("starting playbook %q (deployment %s, resume step %d)", playbookName, deploymentID, resumeStep))
 
-	m.Hub.Send(clientID, common.WSMessage{
+	m.Hub.Send(agentID, common.WSMessage{
 		Type:      common.WSMsgPlaybook,
 		Timestamp: time.Now(),
 		Data: common.WSPlaybookData{
@@ -165,5 +165,3 @@ func (m *Manager) ResolvePlaybookNameByDeployment(deploymentID string) string {
 	}
 	return playbookName
 }
-
-

--- a/internal/server/service/manager_test.go
+++ b/internal/server/service/manager_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 type sentMessage struct {
-	clientID string
-	msg      common.WSMessage
+	agentID string
+	msg     common.WSMessage
 }
 
 type fakeHub struct {
@@ -20,12 +20,12 @@ type fakeHub struct {
 	sent      []sentMessage
 }
 
-func (h *fakeHub) IsConnected(clientID string) bool {
-	return h.connected[clientID]
+func (h *fakeHub) IsConnected(agentID string) bool {
+	return h.connected[agentID]
 }
 
-func (h *fakeHub) Send(clientID string, msg common.WSMessage) bool {
-	h.sent = append(h.sent, sentMessage{clientID: clientID, msg: msg})
+func (h *fakeHub) Send(agentID string, msg common.WSMessage) bool {
+	h.sent = append(h.sent, sentMessage{agentID: agentID, msg: msg})
 	return true
 }
 
@@ -44,18 +44,18 @@ func newTestManager(t *testing.T) (*service.Manager, *store.Store, *fakeHub) {
 	return mgr, st, hub
 }
 
-func saveClientAndPlaybook(t *testing.T, st *store.Store, clientID, playbookID string) {
+func saveAgentAndPlaybook(t *testing.T, st *store.Store, agentID, playbookID string) {
 	t.Helper()
 	now := time.Now()
-	if err := st.SaveClient(&common.Client{
-		ID:             clientID,
+	if err := st.SaveAgent(&common.Agent{
+		ID:             agentID,
 		Hostname:       "edge-1",
 		Platform:       common.PlatformLinux,
-		Status:         common.ClientStatusRegistered,
+		Status:         common.AgentStatusRegistered,
 		RegisteredAt:   now,
 		LastActivityAt: now,
 	}); err != nil {
-		t.Fatalf("SaveClient: %v", err)
+		t.Fatalf("SaveAgent: %v", err)
 	}
 	if err := st.SavePlaybook(&store.PlaybookRecord{
 		ID:   playbookID,
@@ -80,52 +80,52 @@ func saveClientAndPlaybook(t *testing.T, st *store.Store, clientID, playbookID s
 func TestStatusSnapshot(t *testing.T) {
 	mgr, st, _ := newTestManager(t)
 	now := time.Now()
-	_ = st.SaveClient(&common.Client{ID: "c1", Hostname: "h1", Platform: common.PlatformLinux, Status: common.ClientStatusRegistered, RegisteredAt: now, LastActivityAt: now})
-	_ = st.SaveDeployment(&common.DeploymentState{ID: "d1", ClientID: "c1", PlaybookID: "p1", Status: common.DeploymentStatusRunning, StartedAt: now, UpdatedAt: now})
+	_ = st.SaveAgent(&common.Agent{ID: "c1", Hostname: "h1", Platform: common.PlatformLinux, Status: common.AgentStatusRegistered, RegisteredAt: now, LastActivityAt: now})
+	_ = st.SaveDeployment(&common.DeploymentState{ID: "d1", AgentID: "c1", PlaybookID: "p1", Status: common.DeploymentStatusRunning, StartedAt: now, UpdatedAt: now})
 
-	clients, deployments := mgr.StatusSnapshot()
-	if len(clients) != 1 {
-		t.Fatalf("clients len = %d; want 1", len(clients))
+	agents, deployments := mgr.StatusSnapshot()
+	if len(agents) != 1 {
+		t.Fatalf("agents len = %d; want 1", len(agents))
 	}
 	if len(deployments) != 1 {
 		t.Fatalf("deployments len = %d; want 1", len(deployments))
 	}
 }
 
-func TestAssignPlaybookToClientErrors(t *testing.T) {
+func TestAssignPlaybookToAgentErrors(t *testing.T) {
 	mgr, st, _ := newTestManager(t)
 
-	err := mgr.AssignPlaybookToClient("pb-1", "missing-client")
-	if !errors.Is(err, service.ErrClientNotFound) {
-		t.Fatalf("expected ErrClientNotFound, got %v", err)
+	err := mgr.AssignPlaybookToAgent("pb-1", "missing-agent")
+	if !errors.Is(err, service.ErrAgentNotFound) {
+		t.Fatalf("expected ErrAgentNotFound, got %v", err)
 	}
 
 	now := time.Now()
-	_ = st.SaveClient(&common.Client{ID: "c1", Hostname: "h1", Platform: common.PlatformLinux, Status: common.ClientStatusRegistered, RegisteredAt: now, LastActivityAt: now})
-	err = mgr.AssignPlaybookToClient("missing-playbook", "c1")
+	_ = st.SaveAgent(&common.Agent{ID: "c1", Hostname: "h1", Platform: common.PlatformLinux, Status: common.AgentStatusRegistered, RegisteredAt: now, LastActivityAt: now})
+	err = mgr.AssignPlaybookToAgent("missing-playbook", "c1")
 	if !errors.Is(err, service.ErrPlaybookNotFound) {
 		t.Fatalf("expected ErrPlaybookNotFound, got %v", err)
 	}
 }
 
-func TestAssignPlaybookToClientConnectedPushesPlaybook(t *testing.T) {
+func TestAssignPlaybookToAgentConnectedPushesPlaybook(t *testing.T) {
 	mgr, st, hub := newTestManager(t)
-	saveClientAndPlaybook(t, st, "c1", "pb-1")
+	saveAgentAndPlaybook(t, st, "c1", "pb-1")
 	hub.connected["c1"] = true
 
-	if err := mgr.AssignPlaybookToClient("pb-1", "c1"); err != nil {
-		t.Fatalf("AssignPlaybookToClient: %v", err)
+	if err := mgr.AssignPlaybookToAgent("pb-1", "c1"); err != nil {
+		t.Fatalf("AssignPlaybookToAgent: %v", err)
 	}
 
-	client, ok := st.GetClient("c1")
+	agent, ok := st.GetAgent("c1")
 	if !ok {
-		t.Fatal("client not found")
+		t.Fatal("agent not found")
 	}
-	if client.PlaybookID != "pb-1" {
-		t.Fatalf("PlaybookID = %q; want pb-1", client.PlaybookID)
+	if agent.PlaybookID != "pb-1" {
+		t.Fatalf("PlaybookID = %q; want pb-1", agent.PlaybookID)
 	}
-	if client.Status != common.ClientStatusDeploying {
-		t.Fatalf("Status = %q; want %q", client.Status, common.ClientStatusDeploying)
+	if agent.Status != common.AgentStatusDeploying {
+		t.Fatalf("Status = %q; want %q", agent.Status, common.AgentStatusDeploying)
 	}
 
 	if len(hub.sent) != 1 {
@@ -146,16 +146,16 @@ func TestAssignPlaybookToClientConnectedPushesPlaybook(t *testing.T) {
 
 func TestPushPlaybookIfAssignedResumesActiveDeployment(t *testing.T) {
 	mgr, st, hub := newTestManager(t)
-	saveClientAndPlaybook(t, st, "c1", "pb-1")
+	saveAgentAndPlaybook(t, st, "c1", "pb-1")
 
-	client, _ := st.GetClient("c1")
-	client.PlaybookID = "pb-1"
-	_ = st.SaveClient(client)
+	agent, _ := st.GetAgent("c1")
+	agent.PlaybookID = "pb-1"
+	_ = st.SaveAgent(agent)
 
 	now := time.Now()
 	_ = st.SaveDeployment(&common.DeploymentState{
 		ID:              "dep-1",
-		ClientID:        "c1",
+		AgentID:         "c1",
 		PlaybookID:      "pb-1",
 		Status:          common.DeploymentStatusRunning,
 		ResumeStepIndex: 3,
@@ -182,16 +182,16 @@ func TestPushPlaybookIfAssignedResumesActiveDeployment(t *testing.T) {
 
 func TestPushPlaybookIfAssignedSkipsCompleted(t *testing.T) {
 	mgr, st, hub := newTestManager(t)
-	saveClientAndPlaybook(t, st, "c1", "pb-1")
+	saveAgentAndPlaybook(t, st, "c1", "pb-1")
 
-	client, _ := st.GetClient("c1")
-	client.PlaybookID = "pb-1"
-	_ = st.SaveClient(client)
+	agent, _ := st.GetAgent("c1")
+	agent.PlaybookID = "pb-1"
+	_ = st.SaveAgent(agent)
 
 	now := time.Now()
 	_ = st.SaveDeployment(&common.DeploymentState{
 		ID:         "dep-done",
-		ClientID:   "c1",
+		AgentID:    "c1",
 		PlaybookID: "pb-1",
 		Status:     common.DeploymentStatusDone,
 		StartedAt:  now.Add(-time.Hour),
@@ -247,7 +247,7 @@ func TestAppendDeploymentLogAndResolvePlaybookName(t *testing.T) {
 		CreatedAt: now,
 		UpdatedAt: now,
 	})
-	_ = st.SaveDeployment(&common.DeploymentState{ID: "dep-2", ClientID: "c1", PlaybookID: "pb-2", Status: common.DeploymentStatusRunning, StartedAt: now, UpdatedAt: now})
+	_ = st.SaveDeployment(&common.DeploymentState{ID: "dep-2", AgentID: "c1", PlaybookID: "pb-2", Status: common.DeploymentStatusRunning, StartedAt: now, UpdatedAt: now})
 
 	if got := mgr.ResolvePlaybookNameByDeployment("dep-2"); got != "yaml-name" {
 		t.Fatalf("playbook name = %q; want yaml-name", got)

--- a/internal/server/store/store.go
+++ b/internal/server/store/store.go
@@ -1,6 +1,6 @@
 // Package store provides a JSON-file-backed persistence layer for the kompakt server.
 // Design notes:
-//   - All client/deployment/playbook/artifact/secret state lives in state.json.
+//   - All agent/deployment/playbook/artifact/secret state lives in state.json.
 //   - Logs are stored in per-deployment files under logsDir/{deploymentID}.json
 //     so that a large deployment never inflates the main state snapshot.
 package store
@@ -33,11 +33,11 @@ type Store struct {
 	mu          sync.RWMutex
 	stateFile   string
 	logsDir     string
-	clients     map[string]*common.Client
+	agents      map[string]*common.Agent
 	deployments map[string]*common.DeploymentState
 	playbooks   map[string]*PlaybookRecord
 	artifacts   map[string]*common.Artifact
-	secrets     map[string]string // client secrets (name→value)
+	secrets     map[string]string // agent secrets (name→value)
 
 	// logMutexesMu protects logMutexes; logMutexes holds a per-deployment mutex so that
 	// concurrent log reads/writes for the same deployment are serialised without
@@ -49,7 +49,7 @@ type Store struct {
 // snapshot is the structure serialised to state.json.
 // Logs are intentionally excluded — they live in separate files.
 type snapshot struct {
-	Clients     map[string]*common.Client          `json:"clients"`
+	Agents      map[string]*common.Agent          `json:"agents"`
 	Deployments map[string]*common.DeploymentState `json:"deployments"`
 	Playbooks   map[string]*PlaybookRecord         `json:"playbooks"`
 	Artifacts   map[string]*common.Artifact        `json:"artifacts"`
@@ -71,7 +71,7 @@ func New(dir string, logsDir string) (*Store, error) {
 	s := &Store{
 		stateFile:   filepath.Join(dir, "state.json"),
 		logsDir:     logsDir,
-		clients:     make(map[string]*common.Client),
+		agents:      make(map[string]*common.Agent),
 		deployments: make(map[string]*common.DeploymentState),
 		playbooks:   make(map[string]*PlaybookRecord),
 		artifacts:   make(map[string]*common.Artifact),
@@ -105,8 +105,8 @@ func (s *Store) load() error {
 	if err := json.Unmarshal(data, &snap); err != nil {
 		return fmt.Errorf("parsing store: %w", err)
 	}
-	if snap.Clients != nil {
-		s.clients = snap.Clients
+	if snap.Agents != nil {
+		s.agents = snap.Agents
 	}
 	if snap.Deployments != nil {
 		s.deployments = snap.Deployments
@@ -120,28 +120,28 @@ func (s *Store) load() error {
 	if snap.Secrets != nil {
 		s.secrets = snap.Secrets
 	}
-	for _, c := range s.clients {
-		migrateLegacyClientFields(c)
+	for _, a := range s.agents {
+		migrateLegacyAgentFields(a)
 	}
 	return nil
 }
 
-func migrateLegacyClientFields(c *common.Client) {
-	if c == nil || c.Metadata == nil {
+func migrateLegacyAgentFields(a *common.Agent) {
+	if a == nil || a.Metadata == nil {
 		return
 	}
-	if strings.TrimSpace(c.OS) == "" {
-		if osDesc := strings.TrimSpace(c.Metadata["os_description"]); osDesc != "" {
-			c.OS = osDesc
-		} else if osName := strings.TrimSpace(c.Metadata["os"]); osName != "" {
-			c.OS = osName
+	if strings.TrimSpace(a.OS) == "" {
+		if osDesc := strings.TrimSpace(a.Metadata["os_description"]); osDesc != "" {
+			a.OS = osDesc
+		} else if osName := strings.TrimSpace(a.Metadata["os"]); osName != "" {
+			a.OS = osName
 		}
 	}
-	if strings.TrimSpace(c.Vendor) == "" {
-		c.Vendor = strings.TrimSpace(c.Metadata["vendor"])
+	if strings.TrimSpace(a.Vendor) == "" {
+		a.Vendor = strings.TrimSpace(a.Metadata["vendor"])
 	}
-	if strings.TrimSpace(c.Model) == "" {
-		c.Model = strings.TrimSpace(c.Metadata["model"])
+	if strings.TrimSpace(a.Model) == "" {
+		a.Model = strings.TrimSpace(a.Metadata["model"])
 	}
 }
 
@@ -186,7 +186,7 @@ func platformFromOS(osName string, metadata map[string]string) common.PlatformTy
 // save must be called with s.mu held (write lock).
 func (s *Store) save() error {
 	snap := snapshot{
-		Clients:     s.clients,
+		Agents:      s.agents,
 		Deployments: s.deployments,
 		Playbooks:   s.playbooks,
 		Artifacts:   s.artifacts,
@@ -203,33 +203,33 @@ func (s *Store) save() error {
 	return os.Rename(tmp, s.stateFile)
 }
 
-// ── Clients ───────────────────────────────────────────────────────────────────
+// ── Agents ────────────────────────────────────────────────────────────────────
 
-func (s *Store) SaveClient(c *common.Client) error {
+func (s *Store) SaveAgent(a *common.Agent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	c.Platform = normalizePlatform(c.Platform, c.OS, c.Metadata)
-	cc := cloneClient(c)
-	s.clients[cc.ID] = cc
+	a.Platform = normalizePlatform(a.Platform, a.OS, a.Metadata)
+	ac := cloneAgent(a)
+	s.agents[ac.ID] = ac
 	return s.save()
 }
 
-func (s *Store) GetClient(id string) (*common.Client, bool) {
+func (s *Store) GetAgent(id string) (*common.Agent, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	c, ok := s.clients[id]
+	a, ok := s.agents[id]
 	if !ok {
 		return nil, false
 	}
-	return cloneClient(c), true
+	return cloneAgent(a), true
 }
 
-func (s *Store) ListClients() []*common.Client {
+func (s *Store) ListAgents() []*common.Agent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	out := make([]*common.Client, 0, len(s.clients))
-	for _, c := range s.clients {
-		out = append(out, cloneClient(c))
+	out := make([]*common.Agent, 0, len(s.agents))
+	for _, a := range s.agents {
+		out = append(out, cloneAgent(a))
 	}
 	sort.Slice(out, func(i, j int) bool {
 		hi := strings.ToLower(strings.TrimSpace(out[i].Hostname))
@@ -248,10 +248,10 @@ func (s *Store) ListClients() []*common.Client {
 	return out
 }
 
-func (s *Store) DeleteClient(id string) error {
+func (s *Store) DeleteAgent(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.clients, id)
+	delete(s.agents, id)
 	return s.save()
 }
 
@@ -275,14 +275,14 @@ func (s *Store) GetDeployment(id string) (*common.DeploymentState, bool) {
 	return d, true
 }
 
-// GetActiveDeploymentForClient returns the most recent non-terminal deployment
-// for a client (running or rebooting), or any deployment if none is active.
-func (s *Store) GetActiveDeploymentForClient(clientID string) (*common.DeploymentState, bool) {
+// GetActiveDeploymentForAgent returns the most recent non-terminal deployment
+// for an agent (running or rebooting), or any deployment if none is active.
+func (s *Store) GetActiveDeploymentForAgent(agentID string) (*common.DeploymentState, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	var latest *common.DeploymentState
 	for _, d := range s.deployments {
-		if d.ClientID != clientID {
+		if d.AgentID != agentID {
 			continue
 		}
 		if latest == nil || d.StartedAt.After(latest.StartedAt) {
@@ -313,10 +313,10 @@ func (s *Store) enrichDeploymentLocked(d *common.DeploymentState) {
 	if d == nil {
 		return
 	}
-	if c, ok := s.clients[d.ClientID]; ok {
-		d.Hostname = c.Hostname
+	if a, ok := s.agents[d.AgentID]; ok {
+		d.Hostname = a.Hostname
 	} else {
-		d.Hostname = "Deleted Client"
+		d.Hostname = "Deleted Agent"
 	}
 	if p, ok := s.playbooks[d.PlaybookID]; ok {
 		d.PlaybookName = p.Name
@@ -419,7 +419,7 @@ func (s *Store) ListArtifacts() []*common.Artifact {
 	return out
 }
 
-func cloneClient(in *common.Client) *common.Client {
+func cloneAgent(in *common.Agent) *common.Agent {
 	if in == nil {
 		return nil
 	}
@@ -637,12 +637,12 @@ func (s *Store) GetLogsForDeployment(deploymentID string) []*common.LogEntry {
 	return s.readDeploymentLogsLocked(s.logPath(deploymentID))
 }
 
-// GetLogsForClient returns all log entries for every deployment of a client.
-func (s *Store) GetLogsForClient(clientID string) []*common.LogEntry {
+// GetLogsForAgent returns all log entries for every deployment of an agent.
+func (s *Store) GetLogsForAgent(agentID string) []*common.LogEntry {
 	s.mu.RLock()
 	deploymentIDs := make([]string, 0)
 	for _, d := range s.deployments {
-		if d.ClientID == clientID {
+		if d.AgentID == agentID {
 			deploymentIDs = append(deploymentIDs, d.ID)
 		}
 	}

--- a/internal/server/store/store_test.go
+++ b/internal/server/store/store_test.go
@@ -19,79 +19,79 @@ func newTestStore(t *testing.T) *store.Store {
 	return s
 }
 
-// ── Clients ───────────────────────────────────────────────────────────────────
+// ── Agents ────────────────────────────────────────────────────────────────────
 
-func TestClientCRUD(t *testing.T) {
+func TestAgentCRUD(t *testing.T) {
 	s := newTestStore(t)
 
-	c := &common.Client{
-		ID:             "client-1",
+	a := &common.Agent{
+		ID:             "agent-1",
 		Hostname:       "edge-01",
 		Platform:       common.PlatformLinux,
-		Status:         common.ClientStatusRegistered,
+		Status:         common.AgentStatusRegistered,
 		RegisteredAt:   time.Now(),
 		LastActivityAt: time.Now(),
 	}
-	if err := s.SaveClient(c); err != nil {
-		t.Fatalf("SaveClient: %v", err)
+	if err := s.SaveAgent(a); err != nil {
+		t.Fatalf("SaveAgent: %v", err)
 	}
 
-	got, ok := s.GetClient("client-1")
+	got, ok := s.GetAgent("agent-1")
 	if !ok {
-		t.Fatal("GetClient: not found")
+		t.Fatal("GetAgent: not found")
 	}
 	if got.Hostname != "edge-01" {
 		t.Errorf("Hostname = %q; want edge-01", got.Hostname)
 	}
 
-	list := s.ListClients()
+	list := s.ListAgents()
 	if len(list) != 1 {
-		t.Errorf("ListClients len = %d; want 1", len(list))
+		t.Errorf("ListAgents len = %d; want 1", len(list))
 	}
 
-	if err := s.DeleteClient("client-1"); err != nil {
-		t.Fatalf("DeleteClient: %v", err)
+	if err := s.DeleteAgent("agent-1"); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
 	}
-	_, ok = s.GetClient("client-1")
+	_, ok = s.GetAgent("agent-1")
 	if ok {
-		t.Error("expected client to be deleted")
+		t.Error("expected agent to be deleted")
 	}
 }
 
-func TestListClientsStableOrder(t *testing.T) {
+func TestListAgentsStableOrder(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
 
-	clients := []*common.Client{
-		{ID: "id-z", Hostname: "zeta", Status: common.ClientStatusRegistered, RegisteredAt: now, LastActivityAt: now},
-		{ID: "id-a", Hostname: "alpha", Status: common.ClientStatusRegistered, RegisteredAt: now, LastActivityAt: now},
-		{ID: "id-b", Hostname: "", Status: common.ClientStatusRegistered, RegisteredAt: now, LastActivityAt: now},
-		{ID: "id-a2", Hostname: "alpha", Status: common.ClientStatusRegistered, RegisteredAt: now, LastActivityAt: now},
+	agents := []*common.Agent{
+		{ID: "id-z", Hostname: "zeta", Status: common.AgentStatusRegistered, RegisteredAt: now, LastActivityAt: now},
+		{ID: "id-a", Hostname: "alpha", Status: common.AgentStatusRegistered, RegisteredAt: now, LastActivityAt: now},
+		{ID: "id-b", Hostname: "", Status: common.AgentStatusRegistered, RegisteredAt: now, LastActivityAt: now},
+		{ID: "id-a2", Hostname: "alpha", Status: common.AgentStatusRegistered, RegisteredAt: now, LastActivityAt: now},
 	}
-	for _, c := range clients {
-		if err := s.SaveClient(c); err != nil {
-			t.Fatalf("SaveClient(%s): %v", c.ID, err)
+	for _, a := range agents {
+		if err := s.SaveAgent(a); err != nil {
+			t.Fatalf("SaveAgent(%s): %v", a.ID, err)
 		}
 	}
 
-	got := s.ListClients()
+	got := s.ListAgents()
 	if len(got) != 4 {
-		t.Fatalf("ListClients len = %d; want 4", len(got))
+		t.Fatalf("ListAgents len = %d; want 4", len(got))
 	}
 
 	wantIDs := []string{"id-a", "id-a2", "id-z", "id-b"}
 	for i, want := range wantIDs {
 		if got[i].ID != want {
-			t.Fatalf("ListClients[%d].ID = %q; want %q", i, got[i].ID, want)
+			t.Fatalf("ListAgents[%d].ID = %q; want %q", i, got[i].ID, want)
 		}
 	}
 
 	// Call repeatedly to ensure order remains deterministic.
 	for n := 0; n < 3; n++ {
-		again := s.ListClients()
+		again := s.ListAgents()
 		for i, want := range wantIDs {
 			if again[i].ID != want {
-				t.Fatalf("ListClients call %d index %d ID = %q; want %q", n+2, i, again[i].ID, want)
+				t.Fatalf("ListAgents call %d index %d ID = %q; want %q", n+2, i, again[i].ID, want)
 			}
 		}
 	}
@@ -104,7 +104,7 @@ func TestDeploymentCRUD(t *testing.T) {
 
 	d := &common.DeploymentState{
 		ID:              "dep-1",
-		ClientID:        "client-1",
+		AgentID:         "agent-1",
 		PlaybookID:      "pb-1",
 		Status:          common.DeploymentStatusRunning,
 		ResumeStepIndex: 2,
@@ -123,9 +123,9 @@ func TestDeploymentCRUD(t *testing.T) {
 		t.Errorf("ResumeStepIndex = %d; want 2", got.ResumeStepIndex)
 	}
 
-	dep, ok := s.GetActiveDeploymentForClient("client-1")
+	dep, ok := s.GetActiveDeploymentForAgent("agent-1")
 	if !ok {
-		t.Fatal("GetActiveDeploymentForClient: not found")
+		t.Fatal("GetActiveDeploymentForAgent: not found")
 	}
 	if dep.ID != "dep-1" {
 		t.Errorf("deployment ID = %q; want dep-1", dep.ID)
@@ -137,20 +137,20 @@ func TestDeploymentCRUD(t *testing.T) {
 	}
 }
 
-func TestGetActiveDeploymentForClientMostRecent(t *testing.T) {
+func TestGetActiveDeploymentForAgentMostRecent(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
 
 	older := &common.DeploymentState{
 		ID:        "dep-old",
-		ClientID:  "client-1",
+		AgentID:   "agent-1",
 		Status:    common.DeploymentStatusRunning,
 		StartedAt: now.Add(-10 * time.Minute),
 		UpdatedAt: now.Add(-10 * time.Minute),
 	}
 	newer := &common.DeploymentState{
 		ID:        "dep-new",
-		ClientID:  "client-1",
+		AgentID:   "agent-1",
 		Status:    common.DeploymentStatusRunning,
 		StartedAt: now,
 		UpdatedAt: now,
@@ -163,20 +163,20 @@ func TestGetActiveDeploymentForClientMostRecent(t *testing.T) {
 		t.Fatalf("SaveDeployment newer: %v", err)
 	}
 
-	got, ok := s.GetActiveDeploymentForClient("client-1")
+	got, ok := s.GetActiveDeploymentForAgent("agent-1")
 	if !ok {
-		t.Fatal("GetActiveDeploymentForClient: not found")
+		t.Fatal("GetActiveDeploymentForAgent: not found")
 	}
 	if got.ID != "dep-new" {
 		t.Fatalf("deployment ID = %q; want dep-new", got.ID)
 	}
 }
 
-func TestGetActiveDeploymentForClientNotFound(t *testing.T) {
+func TestGetActiveDeploymentForAgentNotFound(t *testing.T) {
 	s := newTestStore(t)
 
-	if _, ok := s.GetActiveDeploymentForClient("missing-client"); ok {
-		t.Fatal("expected no active deployment for unknown client")
+	if _, ok := s.GetActiveDeploymentForAgent("missing-agent"); ok {
+		t.Fatal("expected no active deployment for unknown agent")
 	}
 }
 
@@ -341,13 +341,13 @@ func TestAllSecretsReturnsCopy(t *testing.T) {
 
 // ── Logs — per-deployment files ───────────────────────────────────────────────
 
-func TestLogsQueryByDeploymentAndClient(t *testing.T) {
+func TestLogsQueryByDeploymentAndAgent(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()
 
 	_ = s.SaveDeployment(&common.DeploymentState{
 		ID:        "dep-1",
-		ClientID:  "client-1",
+		AgentID:   "agent-1",
 		StartedAt: now,
 		UpdatedAt: now,
 	})
@@ -365,25 +365,25 @@ func TestLogsQueryByDeploymentAndClient(t *testing.T) {
 		t.Errorf("GetLogsForDeployment(dep-1) len = %d; want 1", len(dep1Logs))
 	}
 
-	clientLogs := s.GetLogsForClient("client-1")
-	if len(clientLogs) != 1 {
-		t.Errorf("GetLogsForClient(client-1) len = %d; want 1", len(clientLogs))
+	agentLogs := s.GetLogsForAgent("agent-1")
+	if len(agentLogs) != 1 {
+		t.Errorf("GetLogsForAgent(agent-1) len = %d; want 1", len(agentLogs))
 	}
 }
 
 // ── Persistence ───────────────────────────────────────────────────────────────
 
-func TestPersistence_ReopenPreservesClientAndSecret(t *testing.T) {
+func TestPersistence_ReopenPreservesAgentAndSecret(t *testing.T) {
 	dir := t.TempDir()
 
 	s1, err := store.New(dir, "")
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
 	}
-	_ = s1.SaveClient(&common.Client{
-		ID:       "c1",
+	_ = s1.SaveAgent(&common.Agent{
+		ID:       "a1",
 		Hostname: "host-1",
-		Status:   common.ClientStatusRegistered,
+		Status:   common.AgentStatusRegistered,
 	})
 	_ = s1.SetSecret("K", "V")
 
@@ -392,12 +392,12 @@ func TestPersistence_ReopenPreservesClientAndSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.New (reopen): %v", err)
 	}
-	c, ok := s2.GetClient("c1")
+	a, ok := s2.GetAgent("a1")
 	if !ok {
-		t.Fatal("client not found after reopen")
+		t.Fatal("agent not found after reopen")
 	}
-	if c.Hostname != "host-1" {
-		t.Errorf("Hostname = %q after reopen; want host-1", c.Hostname)
+	if a.Hostname != "host-1" {
+		t.Errorf("Hostname = %q after reopen; want host-1", a.Hostname)
 	}
 	v, ok := s2.GetSecret("K")
 	if !ok || v != "V" {


### PR DESCRIPTION
This pull request refactors the terminology throughout the codebase, replacing "client" with "agent" to better reflect the system's architecture. It updates struct fields, API endpoints, handler functions, and documentation comments to use the new naming convention. The changes also include updates to tests and permission settings to match the new terminology.

**Terminology Refactor:**

* Renamed all relevant types and fields in `internal/common/types.go` from "client" to "agent", including `Client` → `Agent`, `ClientID` → `AgentID`, `ClientStatus` → `AgentStatus`, and updated associated comments and constants. [[1]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL120-R120) [[2]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL141-R160) [[3]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL169-R169) [[4]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL189-R193) [[5]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL217-R217) [[6]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL241-R241) [[7]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL250-R251) [[8]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL264-R269)
* Refactored API handlers in `internal/server/handlers/admin.go` and related documentation to use "agents" instead of "clients", including renaming endpoints, handler functions, and JSON fields. [[1]](diffhunk://#diff-7b3d8ac114a0b2143954854eca99100d9abdd90c3a5f5bd47315e44d28f27869L22-R22) [[2]](diffhunk://#diff-7b3d8ac114a0b2143954854eca99100d9abdd90c3a5f5bd47315e44d28f27869L35-R36) [[3]](diffhunk://#diff-7b3d8ac114a0b2143954854eca99100d9abdd90c3a5f5bd47315e44d28f27869L186-R190) [[4]](diffhunk://#diff-7b3d8ac114a0b2143954854eca99100d9abdd90c3a5f5bd47315e44d28f27869L200-R202) [[5]](diffhunk://#diff-7b3d8ac114a0b2143954854eca99100d9abdd90c3a5f5bd47315e44d28f27869L212-R250) [[6]](diffhunk://#diff-7b3d8ac114a0b2143954854eca99100d9abdd90c3a5f5bd47315e44d28f27869L262-R274) [[7]](diffhunk://#diff-7b3d8ac114a0b2143954854eca99100d9abdd90c3a5f5bd47315e44d28f27869L342-L352)

**Code and Test Updates:**

* Updated `internal/agent/agent.go` and associated tests to use `AgentID` instead of `ClientID` in the agent's local state, registration, and connection logic. [[1]](diffhunk://#diff-f48445f706f26bd59d7bae605c4445d3c178237d2489223bf9c1a813417d9713L30-R30) [[2]](diffhunk://#diff-f48445f706f26bd59d7bae605c4445d3c178237d2489223bf9c1a813417d9713L111-R113) [[3]](diffhunk://#diff-f48445f706f26bd59d7bae605c4445d3c178237d2489223bf9c1a813417d9713L127-R127) [[4]](diffhunk://#diff-2178c75819cf6edeafce7a7036bc0dd8d77ff59c4340cb992e773a7de68ed621L38-R38) [[5]](diffhunk://#diff-2178c75819cf6edeafce7a7036bc0dd8d77ff59c4340cb992e773a7de68ed621L48-R48) [[6]](diffhunk://#diff-2178c75819cf6edeafce7a7036bc0dd8d77ff59c4340cb992e773a7de68ed621L96-R96) [[7]](diffhunk://#diff-2178c75819cf6edeafce7a7036bc0dd8d77ff59c4340cb992e773a7de68ed621L112-R112) [[8]](diffhunk://#diff-2178c75819cf6edeafce7a7036bc0dd8d77ff59c4340cb992e773a7de68ed621L132-R139)

**Permissions and Authentication:**

* Modified permission settings in `.claude/settings.json` to include new search patterns for "agents" and related files.
* Updated authentication logic in `internal/server/handlers/artifacts.go` to use `agentIDFromToken` instead of `clientIDFromToken`.