### PR TITLE
Update documentation to reflect SQLite integration for state persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ go test ./... -v -count=1
 go test ./... -race -count=1
 
 # Run a single package's tests
-go test ./internal/daemon/handlers/... -v -count=1
+go test ./internal/server/handlers/... -v -count=1
 
 # Lint (requires golangci-lint)
 golangci-lint run ./...
@@ -41,7 +41,7 @@ go run ./cmd/kompakt-agent -config examples/client.config.yml
 
 The project is a two-binary deployment automation system:
 
-- **`cmd/kompakt`** — the central server/daemon. Exposes an HTTP API and web UI. Manages clients, playbooks, deployments, artifacts, and secrets via a JSON-file-backed store (`internal/daemon/store`).
+- **`cmd/kompakt`** — the central server/daemon. Exposes an HTTP API and web UI. Manages agents, playbooks, deployments, artifacts, and secrets via a SQLite-backed store (`internal/server/store`).
 - **`cmd/kompakt-agent`** — the edge execution agent. Registers with the daemon, receives playbooks over WebSocket, executes them step-by-step, and streams logs back.
 
 ### Key packages
@@ -49,13 +49,13 @@ The project is a two-binary deployment automation system:
 | Package | Role |
 | --- | --- |
 | `internal/common` | Shared types, config loading, playbook model, secret resolution |
-| `internal/daemon` | HTTP server wiring, route definitions |
-| `internal/daemon/handlers` | All HTTP/WebSocket handlers; auth middleware (JWT for agents, HTTP Basic for root) |
-| `internal/daemon/service` | Business logic (deployment dispatch, hub management) |
-| `internal/daemon/store` | JSON-file persistence for all daemon state |
-| `internal/client` | Agent run loop: registration, WebSocket connect/reconnect, playbook execution |
-| `internal/client/executor` | Step execution engine (shell, reboot, download/upload artifact) |
-| `internal/client/identity` | Hardware/platform identifier collection for registration |
+| `internal/server` | HTTP server wiring, route definitions |
+| `internal/server/handlers` | All HTTP/WebSocket handlers; auth middleware (JWT for agents, HTTP Basic for root) |
+| `internal/server/service` | Business logic (deployment dispatch, hub management) |
+| `internal/server/store` | SQLite persistence for all server state (`kompakt.db`) |
+| `internal/agent` | Agent run loop: registration, WebSocket connect/reconnect, playbook execution |
+| `internal/agent/executor` | Step execution engine (shell, reboot, download/upload artifact) |
+| `internal/agent/identity` | Hardware/platform identifier collection for registration |
 
 ### Auth model
 
@@ -69,7 +69,7 @@ Playbooks are YAML with ordered `jobs` (list), each containing `steps`. Steps us
 ### Configuration
 
 - Daemon: `config.yml` (paths, TLS, JWT) + `secrets.yml` (root password, registration secrets, client secrets)
-- Agent: `client.config.yml` (server URL, registration secret, platform hint, state file path)
+- Agent: `client.config.yml` (server URL, registration secret, state file path); platform is detected automatically from the OS
 - Both configs are optional on first run — the daemon auto-generates missing credentials and prints them.
 
 ## Module path

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -92,6 +92,6 @@ Artifacts use the `/artifacts` prefix (not `/api/v1`). Access is controlled per 
 
 ## Notes
 
-- All deployment logs are persisted in the daemon's logs directory, not in `state.json`.
+- All state (agents, deployments, playbooks, artifacts, secrets, logs) is persisted in a single SQLite database (`kompakt.db`) in the server's data directory.
 - Agents resume deployments automatically after reboot or crash using the stored `resume_step_index`.
 - Secrets are injected into playbook steps via `${{ secrets.NAME }}` at execution time.


### PR DESCRIPTION
This pull request updates documentation to reflect a major refactoring of the project structure, switching from a "daemon/client" model to a "server/agent" model, and migrating data persistence from JSON files to a single SQLite database. The changes clarify the new architecture and update configuration and API notes accordingly.

Project structure and terminology updates:

* Updated all references from `daemon` and `client` to `server` and `agent` throughout the documentation, including package names and descriptions. (`CLAUDE.md`)
* Changed package descriptions to reflect the new grouping: `internal/server` and `internal/agent` replace `internal/daemon` and `internal/client`, and handlers, service, and store modules are renamed and repointed. (`CLAUDE.md`)

Persistence and configuration changes:

* Updated the description of the central store from JSON-file-backed to SQLite-backed, and clarified that all state is persisted in a single database (`kompakt.db`). (`CLAUDE.md`, `docs/api-endpoints.md`) [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L44-R58) [[2]](diffhunk://#diff-d69b7976ec8b49ff7cdf0185debe3d25dfdadaa0a024aeed091953d458718409L95-R95)
* Revised agent configuration documentation to indicate platform detection is now automatic, rather than requiring manual configuration. (`CLAUDE.md`)

Testing instructions:

* Updated test command examples to use the new package paths reflecting the refactored structure. (`CLAUDE.md`)