### PR TITLE
Add integration tests and CI action

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
       "Bash(grep -n \"^func\\\\|^type\\\\|^const\" /c/git/kompakt/internal/daemon/service/*.go)",
       "Bash(wc -l /c/git/kompakt/internal/daemon/handlers/*.go)",
       "Bash(grep -r \"\"\"clients\"\"\\\\|clients\\\\.html\\\\|clients-table\\\\|partials/clients\" internal/ --include=\"*.go\")",
-      "Bash(go get:*)"
+      "Bash(go get:*)",
+      "Bash(wc -l /c/git/kompakt/internal/server/handlers/*.go)"
     ]
   }
 }

--- a/.github/actions/go-integration-test/action.yml
+++ b/.github/actions/go-integration-test/action.yml
@@ -1,0 +1,16 @@
+name: Go Integration Test
+description: Run integration tests against a real in-process HTTP server
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: true
+
+    - name: Run integration tests
+      shell: bash
+      run: |
+        go test -tags integration ./... -v -race -count=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,22 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run integration tests
+        uses: ./.github/actions/go-integration-test
+
   build:
     name: Build
-    needs: [lint, test]
+    needs: [lint, test, integration-test]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -234,7 +234,7 @@ type LogBatch struct {
 type Artifact struct {
 	ID             string       `json:"id"`
 	Name           string       `json:"name"`
-	Filename       string       `json:"filename"`
+	FileName       string       `json:"filename"`
 	Size           int64        `json:"size"`
 	ContentType    string       `json:"content_type"`
 	AccessPolicy  AccessPolicy `json:"access_policy"`

--- a/internal/server/handlers/artifacts.go
+++ b/internal/server/handlers/artifacts.go
@@ -90,7 +90,7 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		filePath := filepath.Join(e.ArtifactsDir, a.ID, a.Filename)
+		filePath := filepath.Join(e.ArtifactsDir, a.ID, a.FileName)
 		f, err := os.Open(filePath)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "artifact file missing on server")
@@ -102,8 +102,8 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 			ct = "application/octet-stream"
 		}
 		w.Header().Set("Content-Type", ct)
-		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, a.Filename))
-		http.ServeContent(w, r, a.Filename, time.Now(), f)
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, a.FileName))
+		http.ServeContent(w, r, a.FileName, time.Now(), f)
 
 	case http.MethodPost:
 		// Upload requires authentication (root or any client)
@@ -154,7 +154,7 @@ func (e *Handler) HandleArtifacts(w http.ResponseWriter, r *http.Request) {
 		art := &common.Artifact{
 			ID:             artID,
 			Name:           name,
-			Filename:       filename,
+			FileName:       filename,
 			Size:           size,
 			ContentType:    ct,
 			AccessPolicy:   common.AccessPolicy(r.URL.Query().Get("access_policy")),

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -1013,7 +1013,7 @@ func TestHandleArtifacts_ErrorPaths(t *testing.T) {
 	})
 
 	t.Run("download missing file on disk", func(t *testing.T) {
-		art := &common.Artifact{ID: "art-missing-file", Name: "ghost", Filename: "ghost.bin"}
+		art := &common.Artifact{ID: "art-missing-file", Name: "ghost", FileName: "ghost.bin"}
 		if err := env.Store.SaveArtifact(art); err != nil {
 			t.Fatalf("SaveArtifact: %v", err)
 		}

--- a/internal/server/handlers/ui/templates/partials/artifacts-table.html
+++ b/internal/server/handlers/ui/templates/partials/artifacts-table.html
@@ -14,14 +14,14 @@
       <div>{{.Name}}</div>
       <div class="mono sub">{{.ID}}</div>
     </div>
-    <div class="mono">{{.Filename}}</div>
+    <div class="mono">{{.FileName}}</div>
     <div>{{formatSize .Size}}</div>
     <div><span class="badge {{policyClass (print .AccessPolicy)}}" title="{{if .AllowedAgents}}{{range .AllowedAgents}}{{.}} {{end}}{{end}}">{{policyLabel (print .AccessPolicy)}}</span></div>
     <div>{{formatTime .UploadedAt}}</div>
     <div class="card-top-right"><div class="card-menu">
       <button class="menu-btn" title="Actions">⋮</button>
       <div class="menu-dropdown">
-        <button class="menu-item" onclick="downloadArtifact('{{.ID}}','{{.Filename}}')"><i class="m-icon" data-lucide="download"></i> Download</button>
+        <button class="menu-item" onclick="downloadArtifact('{{.ID}}','{{.FileName}}')"><i class="m-icon" data-lucide="download"></i> Download</button>
         <button class="menu-item" onclick="modifyPolicy('{{.ID}}','{{.Name}}','{{.AccessPolicy}}','{{range .AllowedAgents}}{{.}},{{end}}')"><i class="m-icon" data-lucide="shield"></i> Modify Policy</button>
         <button class="menu-item" onclick="removeArtifact('{{.ID}}')"><i class="m-icon" data-lucide="trash-2"></i> Remove</button>
       </div>

--- a/internal/server/handlers/ui_templates.go
+++ b/internal/server/handlers/ui_templates.go
@@ -370,7 +370,7 @@ func (e *Handler) HandlePartialArtifacts(w http.ResponseWriter, r *http.Request)
 	var filtered []*common.Artifact
 	for _, a := range all {
 		if q != "" {
-			hay := strings.ToLower(a.ID + " " + a.Name + " " + a.Filename)
+			hay := strings.ToLower(a.ID + " " + a.Name + " " + a.FileName)
 			if !strings.Contains(hay, q) {
 				continue
 			}

--- a/internal/server/integration_auth_test.go
+++ b/internal/server/integration_auth_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestIntegration_UILogin_Success(t *testing.T) {
+	env := newIntegrationEnv(t)
+	token := env.rootUIToken(t) // fatals on failure
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+}
+
+func TestIntegration_UILogin_WrongPassword(t *testing.T) {
+	env := newIntegrationEnv(t)
+	body, _ := json.Marshal(map[string]string{"password": "bad-password"})
+	resp, err := env.client.Post(env.srv.URL+"/api/v1/ui/login", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", resp.StatusCode)
+	}
+}
+
+func TestIntegration_UILogin_MethodNotAllowed(t *testing.T) {
+	env := newIntegrationEnv(t)
+	resp, err := env.client.Get(env.srv.URL + "/api/v1/ui/login")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d; want 405", resp.StatusCode)
+	}
+}
+
+func TestIntegration_RootAPI_BasicAuth(t *testing.T) {
+	env := newIntegrationEnv(t)
+	resp := env.get(t, "/api/v1/status", basicAuthHeader(intTestRootPassword))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d; want 200 (body: %s)", resp.StatusCode, b)
+	}
+}
+
+func TestIntegration_RootAPI_WrongBasicAuth(t *testing.T) {
+	env := newIntegrationEnv(t)
+	resp := env.get(t, "/api/v1/status", basicAuthHeader("wrong-password"))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", resp.StatusCode)
+	}
+	const wantHeader = `Basic realm="kompakt-root"`
+	if got := resp.Header.Get("WWW-Authenticate"); got != wantHeader {
+		t.Errorf("WWW-Authenticate = %q; want %q", got, wantHeader)
+	}
+}
+
+func TestIntegration_RootAPI_NoAuth(t *testing.T) {
+	env := newIntegrationEnv(t)
+	resp := env.get(t, "/api/v1/status", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", resp.StatusCode)
+	}
+}
+
+// The UI JWT obtained from /api/v1/ui/login must work for root-protected endpoints.
+func TestIntegration_RootAPI_UIToken(t *testing.T) {
+	env := newIntegrationEnv(t)
+	token := env.rootUIToken(t)
+	resp := env.get(t, "/api/v1/status", "Bearer "+token)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d; want 200 (body: %s)", resp.StatusCode, b)
+	}
+}
+
+// An agent JWT must not be accepted by root-protected endpoints (audience mismatch).
+func TestIntegration_RootAPI_AgentTokenRejected(t *testing.T) {
+	env := newIntegrationEnv(t)
+	agentToken := env.registerAgent(t, "test-host")
+	resp := env.get(t, "/api/v1/status", "Bearer "+agentToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("agent token should not access root endpoint: status = %d; want 401", resp.StatusCode)
+	}
+}
+
+// A UI JWT must not be accepted by agent-only endpoints.
+func TestIntegration_AgentWS_UITokenRejected(t *testing.T) {
+	env := newIntegrationEnv(t)
+	token := env.rootUIToken(t)
+	// WebSocket upgrade will fail, but we can verify the token is rejected at the HTTP layer.
+	req, _ := http.NewRequest(http.MethodGet, env.srv.URL+"/api/v1/ws?token="+token, nil)
+	resp, err := env.client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	// Should be 401 (bad token) or 400 (not a WS upgrade), not 101 (Switching Protocols).
+	if resp.StatusCode == http.StatusSwitchingProtocols {
+		t.Errorf("UI JWT should not be accepted for WebSocket upgrade")
+	}
+}

--- a/internal/server/integration_helpers_test.go
+++ b/internal/server/integration_helpers_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/marko-stanojevic/kompakt/internal/common"
+	"github.com/marko-stanojevic/kompakt/internal/server"
+	"github.com/marko-stanojevic/kompakt/internal/server/handlers"
+	"github.com/marko-stanojevic/kompakt/internal/server/service"
+	"github.com/marko-stanojevic/kompakt/internal/server/store"
+)
+
+const (
+	intTestRootPassword = "integration-test-root-pass"
+	intTestRegSecret    = "integration-test-reg-secret"
+)
+
+// integrationEnv holds a live httptest.Server wired with real routing.
+type integrationEnv struct {
+	srv     *httptest.Server
+	handler *handlers.Handler
+	client  *http.Client
+}
+
+func newIntegrationEnv(t *testing.T) *integrationEnv {
+	t.Helper()
+	st, err := store.New(t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	hub := handlers.NewHub()
+	h := &handlers.Handler{
+		Store:               st,
+		AgentJWTSecret:      []byte("agent-secret-32-bytes-padding!!!"),
+		UserJWTSecret:       []byte("user-secret-32-bytes-padding!!!!"),
+		RootPassword:        intTestRootPassword,
+		TokenExpiryHours:    24,
+		ArtifactsDir:        t.TempDir(),
+		RegistrationSecrets: map[string]string{"default": intTestRegSecret},
+		Hub:                 hub,
+	}
+	h.Service = &service.Manager{Store: st, Hub: hub, ServerURL: "http://placeholder"}
+	srv := httptest.NewServer(server.NewServer(h))
+	t.Cleanup(srv.Close)
+	h.ServerURL = srv.URL
+	h.Service.ServerURL = srv.URL
+	return &integrationEnv{srv: srv, handler: h, client: srv.Client()}
+}
+
+// rootUIToken logs in with the root password and returns a UI Bearer JWT.
+func (e *integrationEnv) rootUIToken(t *testing.T) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"password": intTestRootPassword})
+	resp, err := e.client.Post(e.srv.URL+"/api/v1/ui/login", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("ui/login: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("ui/login status=%d body=%s", resp.StatusCode, b)
+	}
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode login response: %v", err)
+	}
+	if result.Token == "" {
+		t.Fatal("ui/login returned empty token")
+	}
+	return result.Token
+}
+
+// get issues a GET with an optional Authorization header.
+func (e *integrationEnv) get(t *testing.T, path, authHeader string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, e.srv.URL+path, nil)
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	return resp
+}
+
+// basicAuthHeader returns an Authorization header value for root Basic auth.
+func basicAuthHeader(password string) string {
+	req, _ := http.NewRequest(http.MethodGet, "http://x", nil)
+	req.SetBasicAuth("root", password)
+	return req.Header.Get("Authorization")
+}
+
+// registerAgent registers a test agent and returns its JWT.
+func (e *integrationEnv) registerAgent(t *testing.T, hostname string) string {
+	t.Helper()
+	body, _ := json.Marshal(common.RegistrationRequest{
+		Platform:           common.PlatformLinux,
+		Hostname:           hostname,
+		RegistrationSecret: intTestRegSecret,
+	})
+	resp, err := e.client.Post(e.srv.URL+"/api/v1/register", "application/json", bytes.NewReader(body))
+	if err != nil || resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("register: status=%d err=%v body=%s", resp.StatusCode, err, b)
+	}
+	defer resp.Body.Close()
+	var reg common.RegistrationResponse
+	_ = json.NewDecoder(resp.Body).Decode(&reg)
+	return reg.Token
+}

--- a/internal/server/integration_partials_test.go
+++ b/internal/server/integration_partials_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marko-stanojevic/kompakt/internal/common"
+	"github.com/marko-stanojevic/kompakt/internal/server/store"
+)
+
+var allPartialPaths = []string{
+	"/ui/partials/home-stats",
+	"/ui/partials/agents",
+	"/ui/partials/playbooks",
+	"/ui/partials/deployments",
+	"/ui/partials/artifacts",
+	"/ui/partials/vault",
+}
+
+// Every HTMX partial must return 401 without authentication.
+func TestIntegration_Partials_RequireAuth(t *testing.T) {
+	env := newIntegrationEnv(t)
+	for _, path := range allPartialPaths {
+		t.Run(path, func(t *testing.T) {
+			resp := env.get(t, path, "")
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("status = %d; want 401", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// Every partial must render valid HTML (200 + text/html) even when the DB is empty,
+// and must include the expected marker rather than a blank or broken response.
+func TestIntegration_Partials_EmptyState(t *testing.T) {
+	env := newIntegrationEnv(t)
+	auth := "Bearer " + env.rootUIToken(t)
+
+	// home-stats has no empty state — it always renders a dashboard grid.
+	// The remaining partials all render a class="empty" div when the DB is empty.
+	t.Run("/ui/partials/home-stats", func(t *testing.T) {
+		resp := env.get(t, "/ui/partials/home-stats", auth)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d; want 200 (body: %s)", resp.StatusCode, b)
+		}
+		if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+			t.Errorf("Content-Type = %q; want text/html", ct)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(string(body), `class="dashboard-grid"`) {
+			t.Errorf("missing dashboard-grid marker in body:\n%s", body)
+		}
+	})
+
+	for _, path := range allPartialPaths[1:] { // skip /ui/partials/home-stats
+		t.Run(path, func(t *testing.T) {
+			resp := env.get(t, path, auth)
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				b, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d; want 200 (body: %s)", resp.StatusCode, b)
+			}
+			if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+				t.Errorf("Content-Type = %q; want text/html", ct)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			if !strings.Contains(string(body), `class="empty"`) {
+				t.Errorf("missing empty-state marker in body:\n%s", body)
+			}
+		})
+	}
+}
+
+// When the DB contains records, each table partial must render the data rows
+// rather than falling through to the empty state.
+func TestIntegration_Partials_WithData(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	agent := &common.Agent{
+		ID:             common.NewID(),
+		Hostname:       "seed-host",
+		Platform:       common.PlatformLinux,
+		Status:         common.AgentStatusConnected,
+		RegisteredAt:   time.Now(),
+		LastActivityAt: time.Now(),
+	}
+	if err := env.handler.Store.SaveAgent(agent); err != nil {
+		t.Fatalf("save agent: %v", err)
+	}
+
+	pb := &store.PlaybookRecord{
+		ID:        common.NewID(),
+		Name:      "seed-playbook",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	if err := env.handler.Store.SavePlaybook(pb); err != nil {
+		t.Fatalf("save playbook: %v", err)
+	}
+
+	dep := &common.DeploymentState{
+		ID:         common.NewID(),
+		AgentID:    agent.ID,
+		PlaybookID: pb.ID,
+		Status:     common.DeploymentStatusRunning,
+	}
+	if err := env.handler.Store.SaveDeployment(dep); err != nil {
+		t.Fatalf("save deployment: %v", err)
+	}
+
+	if err := env.handler.Store.SetSecret("TEST_KEY", "secret-value"); err != nil {
+		t.Fatalf("set secret: %v", err)
+	}
+
+	art := &common.Artifact{
+		ID:           common.NewID(),
+		Name:         "seed-artifact",
+		FileName:     "seed.bin",
+		ContentType:  "application/octet-stream",
+		Size:         1024,
+		UploadedAt:   time.Now(),
+		AccessPolicy: common.AccessPublic,
+	}
+	if err := env.handler.Store.SaveArtifact(art); err != nil {
+		t.Fatalf("save artifact: %v", err)
+	}
+
+	auth := "Bearer " + env.rootUIToken(t)
+
+	tableTests := []struct {
+		path   string
+		marker string
+	}{
+		{"/ui/partials/agents", `class="list list-agents"`},
+		{"/ui/partials/playbooks", `class="list list-playbooks"`},
+		{"/ui/partials/deployments", `class="list list-deployments"`},
+		{"/ui/partials/vault", `class="list list-secrets"`},
+		{"/ui/partials/artifacts", `class="list list-artifacts"`},
+	}
+
+	for _, tc := range tableTests {
+		t.Run(tc.path, func(t *testing.T) {
+			resp := env.get(t, tc.path, auth)
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				b, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d; want 200 (body: %s)", resp.StatusCode, b)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			if !strings.Contains(string(body), tc.marker) {
+				t.Errorf("missing table marker %q in body:\n%s", tc.marker, body)
+			}
+		})
+	}
+}

--- a/internal/server/integration_ui_test.go
+++ b/internal/server/integration_ui_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package server_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIntegration_Healthz(t *testing.T) {
+	env := newIntegrationEnv(t)
+	resp, err := env.client.Get(env.srv.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d; want 200", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if string(b) != "ok" {
+		t.Errorf("body = %q; want ok", b)
+	}
+}
+
+// UI page shells are public — no auth required. The in-page JS handles auth
+// for API calls. A 401 or 500 here means a regression in template rendering.
+func TestIntegration_UIPages_Accessible(t *testing.T) {
+	env := newIntegrationEnv(t)
+	pages := []string{
+		"/ui", "/ui/agents", "/ui/playbooks",
+		"/ui/deployments", "/ui/vault", "/ui/artifacts",
+	}
+	for _, path := range pages {
+		t.Run(path, func(t *testing.T) {
+			resp := env.get(t, path, "")
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d; want 200 (body: %s)", resp.StatusCode, b)
+			}
+			if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+				t.Errorf("Content-Type = %q; want text/html", ct)
+			}
+		})
+	}
+}

--- a/internal/server/store/store.go
+++ b/internal/server/store/store.go
@@ -463,7 +463,7 @@ func (s *Store) SaveArtifact(a *common.Artifact) error {
 		    name=excluded.name, filename=excluded.filename, size=excluded.size,
 		    content_type=excluded.content_type, access_policy=excluded.access_policy,
 		    allowed_agents_json=excluded.allowed_agents_json`,
-		a.ID, a.Name, a.Filename, a.Size, a.ContentType,
+		a.ID, a.Name, a.FileName, a.Size, a.ContentType,
 		string(a.AccessPolicy), string(agentsJSON), encodeTime(a.UploadedAt),
 	)
 	return err
@@ -529,7 +529,7 @@ func scanArtifact(r scanner) (*common.Artifact, error) {
 	return &common.Artifact{
 		ID:            id,
 		Name:          name,
-		Filename:      filename,
+		FileName:      filename,
 		Size:          size,
 		ContentType:   contentType,
 		AccessPolicy:  common.AccessPolicy(accessPolicy),

--- a/internal/server/store/store_test.go
+++ b/internal/server/store/store_test.go
@@ -235,7 +235,7 @@ func TestArtifactCRUD(t *testing.T) {
 	a := &common.Artifact{
 		ID:         "art-1",
 		Name:       "myapp",
-		Filename:   "myapp.tar.gz",
+		FileName:   "myapp.tar.gz",
 		Size:       1024,
 		UploadedAt: time.Now(),
 	}
@@ -247,8 +247,8 @@ func TestArtifactCRUD(t *testing.T) {
 	if !ok {
 		t.Fatal("GetArtifact: not found")
 	}
-	if got.Filename != "myapp.tar.gz" {
-		t.Errorf("Filename = %q; want myapp.tar.gz", got.Filename)
+	if got.FileName != "myapp.tar.gz" {
+		t.Errorf("FileName = %q; want myapp.tar.gz", got.FileName)
 	}
 
 	byName, ok := s.GetArtifactByName("myapp")


### PR DESCRIPTION
This pull request introduces integration tests for the server's authentication, UI, and partial rendering endpoints, and standardizes the `Artifact` struct's filename field from `Filename` to `FileName` across the codebase. It also adds a reusable GitHub Actions workflow for running Go integration tests and updates the CI pipeline to include these tests. The key changes are grouped below:

**Integration Testing Infrastructure:**

- Added new integration test suites covering authentication flows, UI accessibility, and partial HTML rendering for the server. These tests ensure endpoints behave correctly under various authentication scenarios and validate rendered HTML for both empty and populated database states (`internal/server/integration_auth_test.go`, `internal/server/integration_ui_test.go`, `internal/server/integration_partials_test.go`) [[1]](diffhunk://#diff-a45793eaccdff0674b4c0394ff33ed9b327dda75ef922351127ff6205fa7ce66R1-R116) [[2]](diffhunk://#diff-ae05f63de0d1f19379e26bb54b2377d727a08cf62255087958b476f9f1a20081R1-R49) [[3]](diffhunk://#diff-0a7a1c840274f9bbb3234505457c85ea3d5a901b0407de0cb156df701f0048d7R1-R163).
- Introduced test helpers to spin up a real HTTP server with a temporary database and utility functions for common test actions (`internal/server/integration_helpers_test.go`).

**CI/CD Pipeline Enhancements:**

- Added a reusable composite GitHub Action to run Go integration tests using a real in-process HTTP server (`.github/actions/go-integration-test/action.yml`).
- Updated the main CI workflow to run integration tests as part of the build process, ensuring code changes are validated against real-world scenarios (`.github/workflows/ci.yml`).

**Artifact Struct Field Standardization:**

- Renamed the `Artifact` struct field from `Filename` to `FileName` to maintain consistency and updated all usages throughout the backend, HTML templates, and tests (`internal/common/types.go`, `internal/server/handlers/artifacts.go`, `internal/server/store/store.go`, `internal/server/handlers/ui/templates/partials/artifacts-table.html`, and related test files) [[1]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL237-R237) [[2]](diffhunk://#diff-16db734309ed61ddbc43f8ea6eff986618e98626802a31bf2469acca66ba9f82L93-R93) [[3]](diffhunk://#diff-16db734309ed61ddbc43f8ea6eff986618e98626802a31bf2469acca66ba9f82L105-R106) [[4]](diffhunk://#diff-16db734309ed61ddbc43f8ea6eff986618e98626802a31bf2469acca66ba9f82L157-R157) [[5]](diffhunk://#diff-2f001a261824209550675a0335df8e3edcad29b95dfeda62a2af2bbd95d05d79L1016-R1016) [[6]](diffhunk://#diff-dc05a7dddb1b152b7eae056dcf04f3291824fa792ddd1ae5c3bd8afd10dbe0e3L466-R466) [[7]](diffhunk://#diff-dc05a7dddb1b152b7eae056dcf04f3291824fa792ddd1ae5c3bd8afd10dbe0e3L532-R532) [[8]](diffhunk://#diff-c77ae5cbf28bef61451c780383255e6baad80e5f7972119fb7831a3e163ca8f0L238-R238) [[9]](diffhunk://#diff-5db120d8f16bd96430f269e224a45aa618534edb384effe40e082a33aef2f537L373-R373) [[10]](diffhunk://#diff-eb4f076989e3f5afb9cbac29cca84ad9d662b32c211b191c7e71b2d18b87baf3L17-R24).

**Developer Tooling:**

- Extended `.claude/settings.json` and related scripts to support line counting for new handler files, aiding codebase analysis and maintenance.

These changes collectively improve test coverage, enforce field naming consistency, and strengthen CI validation for future development.