### PR TITLE
Implement agent token management and update status handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Store credentials and tokens centrally. Inject them into any playbook step with 
 - **Structured playbooks** — ordered jobs and steps with shell execution, artifact operations, and reboot actions in a single YAML definition.
 - **Audit trail** — all deployment logs persisted per deployment; queryable via API and viewable in the UI.
 - **Zero external dependencies** — single static Go binary per component, no container runtime, no orchestrator, no database.
-- **TLS and JWT out of the box** — agent communication is JWT-authenticated; UI sessions use short-lived tokens; TLS termination is built-in.
+- **Opaque agent tokens** — agents authenticate with `kpkt_`-prefixed opaque bearer tokens; only a SHA-256 hash is stored, enabling instant per-agent revocation and zero-downtime rotation. UI sessions use separate short-lived JWTs. TLS termination is built-in.
 
 ## Quick start
 
@@ -104,6 +104,7 @@ See [`examples/playbook.yml`](examples/playbook.yml) for a full multi-phase exam
 
 - [API endpoints](docs/api-endpoints.md) — full HTTP and WebSocket API reference
 - [Playbook model](docs/playbook-model.md) — step types, secret injection, reboot handling, and best practices
+- [Agent authentication](docs/agent-authentication.md) — opaque token design, lifecycle, rotation, and security rationale
 - [Project docs](docs/documentation.md) — FAQ and architecture overview
 
 ## Troubleshooting
@@ -111,7 +112,7 @@ See [`examples/playbook.yml`](examples/playbook.yml) for a full multi-phase exam
 | Symptom | Check |
 | --- | --- |
 | Agent fails to register | `registration_secret` in agent config must match a value in the daemon secrets file |
-| JWT token expired errors | Increase `token_expiry_hours` in daemon config |
+| Agent token rejected | Token may be revoked or expired; re-register the agent to obtain a fresh token |
 | Artifact download fails | Verify the artifact access policy; confirm the client ID is in the allowed list for restricted artifacts |
 | Deployment stuck after reboot | Agent resumes automatically on reconnect — check agent logs for connection errors |
 

--- a/cmd/kompakt/main.go
+++ b/cmd/kompakt/main.go
@@ -56,8 +56,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// ── JWT secrets (agent + UI, persisted across restarts) ──────────────────
-	cfg.AgentJWTSecret = loadOrCreateSecret(cfg.AgentJWTSecret, filepath.Join(cfg.DataDir, ".agent-jwt-secret"))
+	// ── UI JWT secret (persisted across restarts) ─────────────────────────────
 	cfg.UserJWTSecret = loadOrCreateSecret(cfg.UserJWTSecret, filepath.Join(cfg.DataDir, ".ui-jwt-secret"))
 
 	// ── Root password ────────────────────────────────────────────────────────
@@ -100,7 +99,6 @@ func main() {
 	svc := &service.Manager{Store: st, Hub: hub, ServerURL: serverURL(cfg)}
 	env := &handlers.Handler{
 		Store:               st,
-		AgentJWTSecret:      []byte(cfg.AgentJWTSecret),
 		UserJWTSecret:       []byte(cfg.UserJWTSecret),
 		RootPassword:        sec.RootPassword,
 		TokenExpiryHours:    cfg.TokenExpiryHours,

--- a/docs/agent-authentication.md
+++ b/docs/agent-authentication.md
@@ -1,0 +1,102 @@
+# Agent Authentication
+
+Kompakt uses **opaque bearer tokens** for agent-to-server authentication. This document explains the design, lifecycle, and security properties of these tokens.
+
+## Token format
+
+Each token is a 32-byte cryptographically random value encoded as:
+
+```
+kpkt_<64 lowercase hex characters>
+```
+
+Example: `kpkt_3f2a1b8e...` (64 hex chars after the prefix)
+
+The `kpkt_` prefix makes tokens easy to identify in logs and secret scanners.
+
+## How tokens are stored
+
+The raw token is **never persisted**. Only its SHA-256 hash is written to the `agent_tokens` table in the SQLite database:
+
+```sql
+CREATE TABLE agent_tokens (
+    id         TEXT PRIMARY KEY,
+    agent_id   TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL,
+    expires_at TEXT,   -- NULL means no expiry
+    revoked_at TEXT    -- NULL means active
+);
+```
+
+This means a database compromise does not expose any usable tokens.
+
+## Lifecycle
+
+### Issuance
+
+Tokens are issued during agent registration (`POST /api/v1/register`). The server returns the raw token **once** — it is never shown again. The agent is responsible for persisting it in its state file.
+
+On re-registration (same agent ID), all previous tokens for that agent are revoked before a new one is issued. This ensures a re-imaged or reconfigured node cannot have stale tokens still accepted.
+
+### Validation
+
+On every authenticated request the server:
+
+1. Extracts the raw token from the `Authorization: Bearer <token>` header or the `?token=` query parameter (used on WebSocket upgrade).
+2. Computes `SHA-256(raw token)`.
+3. Looks up the hash in `agent_tokens`.
+4. Rejects if the token is revoked (`revoked_at IS NOT NULL`) or expired (`expires_at` is in the past).
+5. Returns the associated `agent_id` for downstream handler use.
+
+### Rotation
+
+Agents can rotate their token without re-registering via:
+
+```
+POST /api/v1/token/refresh
+Authorization: Bearer <current-token>
+```
+
+The server issues a new token first, then revokes the old one. This guarantees zero-downtime rotation — there is no window where neither token is valid.
+
+### Revocation
+
+Tokens are revoked in three situations:
+
+| Trigger | Scope |
+|---|---|
+| Agent re-registers | All tokens for that agent |
+| Agent is deleted | All tokens (via `ON DELETE CASCADE`) |
+| Token rotation | Previous token only |
+
+## Why not JWT?
+
+JWTs were considered and rejected for agent tokens for the following reasons:
+
+**No instant revocation.** A JWT is valid until its `exp` claim expires. Revoking a compromised 30-day agent token with pure JWTs would require either a revocation list (which is effectively a database lookup on every request) or cutting the expiry very short. Opaque tokens get true revocation for free.
+
+**Signing key blast radius.** A leaked JWT signing key compromises every token ever issued. A leaked opaque token compromises only that one token.
+
+**Payload exposure.** JWT payloads are base64-decodable by anyone holding the token. Opaque tokens reveal nothing about the agent or server internals.
+
+**Per-agent metadata.** Opaque tokens support per-token expiry, revocation timestamps, and audit records without cramming mutable state into immutable JWT claims.
+
+Opaque tokens are the approach used by GitHub PATs, AWS access keys, Stripe API keys, and Kubernetes service account tokens — all environments with large numbers of long-lived machine credentials requiring independent revocation.
+
+## UI sessions
+
+The web UI uses a separate, short-lived **JWT** (`exp: 8 hours`) issued at `POST /api/v1/ui/login`. This is intentional: UI sessions are interactive, single-user, and have no lifecycle management requirements. The JWT is validated without a database lookup, which is appropriate at the dashboard's interactive scale.
+
+Agent tokens and UI tokens are completely separate systems.
+
+## Security summary
+
+| Property | Agent token | UI JWT |
+|---|---|---|
+| Format | Opaque (`kpkt_<hex>`) | JWT (HS256) |
+| Storage | SHA-256 hash in SQLite | Not stored |
+| Revocation | Instant, per-token | Expiry only (8h max) |
+| Expiry | Configurable, per-token | 8 hours fixed |
+| DB lookup on auth | Yes | No |
+| Compromise blast radius | Single token | All active UI sessions |

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -31,12 +31,7 @@ type ServerConfig struct {
 	TLSCertFile string `yaml:"tls_cert_file"`
 	TLSKeyFile  string `yaml:"tls_key_file"`
 
-	// AgentJWTSecret is used to sign agent tokens.
-	// If empty, a secret is auto-generated and persisted in DataDir.
-	AgentJWTSecret string `yaml:"agent_jwt_secret"`
-
-	// UserJWTSecret is used to sign UI session tokens, kept separate from
-	// agent tokens so rotating one does not invalidate the other.
+	// UserJWTSecret is used to sign UI session tokens.
 	// If empty, a secret is auto-generated and persisted in DataDir.
 	UserJWTSecret string `yaml:"user_jwt_secret"`
 

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -152,7 +152,7 @@ const (
 	AgentStatusRegistered AgentStatus = "registered"
 	AgentStatusConnected  AgentStatus = "connected"
 	AgentStatusDeploying  AgentStatus = "deploying"
-	AgentStatusDone       AgentStatus = "done"
+	AgentStatusCompleted  AgentStatus = "completed"
 	AgentStatusFailed     AgentStatus = "failed"
 	AgentStatusOffline    AgentStatus = "offline"
 )
@@ -183,7 +183,7 @@ const (
 	DeploymentStatusPending   DeploymentStatus = "pending"
 	DeploymentStatusRunning   DeploymentStatus = "running"
 	DeploymentStatusRebooting DeploymentStatus = "rebooting"
-	DeploymentStatusDone      DeploymentStatus = "done"
+	DeploymentStatusCompleted DeploymentStatus = "completed"
 	DeploymentStatusFailed    DeploymentStatus = "failed"
 )
 
@@ -338,4 +338,18 @@ type WSCommandStatus struct {
 	CmdID    string `json:"cmd_id"`
 	ExitCode int    `json:"exit_code"`
 	Error    string `json:"error,omitempty"`
+}
+
+// ── Agent token ───────────────────────────────────────────────────────────────
+
+// AgentToken is a persisted opaque token used for agent authentication.
+// The raw token is only returned once at issuance; TokenHash (SHA-256 hex) is
+// what gets stored in the database.
+type AgentToken struct {
+	ID        string     `json:"id"`
+	AgentID   string     `json:"agent_id"`
+	TokenHash string     `json:"-"` // never returned to clients
+	CreatedAt time.Time  `json:"created_at"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	RevokedAt *time.Time `json:"revoked_at,omitempty"`
 }

--- a/internal/server/handlers/auth.go
+++ b/internal/server/handlers/auth.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -16,73 +17,77 @@ import (
 )
 
 // uiTokenAudience is the JWT audience claim used exclusively for UI session tokens.
-// It prevents a UI token from being accepted by the agent client-auth middleware.
+// It prevents a UI token from being accepted as an agent token.
 const uiTokenAudience = "kompakt-ui"
 
-// ── JWT helpers ───────────────────────────────────────────────────────────────
+// ── Agent token helpers ───────────────────────────────────────────────────────
 
-// issueToken signs a JWT for the given agent ID.
-func (e *Handler) issueToken(agentID string) (string, error) {
+// issueAgentToken generates a cryptographically random opaque token for the
+// given agent, stores a SHA-256 hash of it in the database, and returns the
+// raw token. The raw token is never stored and is only returned once.
+func (e *Handler) issueAgentToken(agentID string) (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating token: %w", err)
+	}
+	raw := "kpkt_" + hex.EncodeToString(b)
 	expiry := time.Duration(e.TokenExpiryHours) * time.Hour
 	if expiry == 0 {
 		expiry = 720 * time.Hour // 30 days default
 	}
-	claims := jwt.RegisteredClaims{
-		Subject:   agentID,
-		IssuedAt:  jwt.NewNumericDate(time.Now()),
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiry)),
+	exp := time.Now().Add(expiry)
+	tok := &common.AgentToken{
+		ID:        common.NewID(),
+		AgentID:   agentID,
+		TokenHash: sha256hex(raw),
+		CreatedAt: time.Now(),
+		ExpiresAt: &exp,
 	}
-	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return tok.SignedString(e.AgentJWTSecret)
+	if err := e.Store.CreateAgentToken(tok); err != nil {
+		return "", fmt.Errorf("storing token: %w", err)
+	}
+	return raw, nil
 }
 
-// agentIDFromToken validates the Bearer token in the request and returns
-// the embedded agent ID.
+// sha256hex returns the SHA-256 hex digest of s.
+func sha256hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// rawTokenFromRequest extracts the raw token string from the Authorization
+// header ("Bearer <token>") or the "token" query parameter.
+func rawTokenFromRequest(r *http.Request) string {
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	return r.URL.Query().Get("token")
+}
+
+// agentIDFromToken looks up the hashed token in the database and returns the
+// associated agent ID, or an error if the token is missing, unknown, revoked,
+// or expired.
 func (e *Handler) agentIDFromToken(r *http.Request) (string, error) {
-	auth := r.Header.Get("Authorization")
-	if !strings.HasPrefix(auth, "Bearer ") {
-		// Also accept token as query parameter (for WebSocket agents that
-		// cannot set headers during the handshake).
-		token := r.URL.Query().Get("token")
-		if token == "" {
-			return "", fmt.Errorf("authentication token is missing or invalid")
-		}
-		return e.parseToken(token)
+	raw := rawTokenFromRequest(r)
+	if raw == "" {
+		return "", fmt.Errorf("authentication token is missing or invalid")
 	}
-	return e.parseToken(strings.TrimPrefix(auth, "Bearer "))
-}
-
-// issueUIToken signs a short-lived (8 h) JWT for a root UI session using the
-// dedicated UI secret, keeping it independent from agent tokens.
-func (e *Handler) issueUIToken() (string, error) {
-	claims := jwt.RegisteredClaims{
-		Subject:   "root",
-		Audience:  jwt.ClaimStrings{uiTokenAudience},
-		IssuedAt:  jwt.NewNumericDate(time.Now()),
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(8 * time.Hour)),
-	}
-	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return tok.SignedString(e.UserJWTSecret)
-}
-
-func (e *Handler) parseToken(raw string) (string, error) {
-	tok, err := jwt.ParseWithClaims(raw, &jwt.RegisteredClaims{},
-		func(_ *jwt.Token) (any, error) { return e.AgentJWTSecret, nil },
-		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}),
-	)
+	tok, err := e.Store.GetAgentTokenByHash(sha256hex(raw))
 	if err != nil {
-		return "", fmt.Errorf("invalid token: %w", err)
+		return "", fmt.Errorf("invalid token")
 	}
-	claims, ok := tok.Claims.(*jwt.RegisteredClaims)
-	if !ok || !tok.Valid {
-		return "", fmt.Errorf("invalid token claims")
+	if tok.RevokedAt != nil {
+		return "", fmt.Errorf("token has been revoked")
 	}
-	return claims.Subject, nil
+	if tok.ExpiresAt != nil && time.Now().After(*tok.ExpiresAt) {
+		return "", fmt.Errorf("token has expired")
+	}
+	return tok.AgentID, nil
 }
 
 // ── Middleware ────────────────────────────────────────────────────────────────
 
-// RequireAgentAuth validates the agent JWT and sets X-Agent-ID for
+// RequireAgentAuth validates the agent token and sets X-Agent-ID for
 // downstream handlers. Also refreshes the agent's last-seen timestamp.
 func (e *Handler) RequireAgentAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -103,9 +108,23 @@ func (e *Handler) RequireAgentAuth(next http.Handler) http.Handler {
 	})
 }
 
+// ── UI JWT helpers ────────────────────────────────────────────────────────────
+
+// issueUIToken signs a short-lived (8 h) JWT for a root UI session using the
+// dedicated UI secret, keeping it independent from agent tokens.
+func (e *Handler) issueUIToken() (string, error) {
+	claims := jwt.RegisteredClaims{
+		Subject:   "root",
+		Audience:  jwt.ClaimStrings{uiTokenAudience},
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(8 * time.Hour)),
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return tok.SignedString(e.UserJWTSecret)
+}
+
 // isRootRequest returns true when the request carries valid root credentials —
 // either HTTP Basic auth or a UI Bearer JWT issued by HandleUILogin.
-// Use this for inline auth checks inside handlers that serve mixed audiences.
 func (e *Handler) isRootRequest(r *http.Request) bool {
 	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
 		raw := strings.TrimPrefix(auth, "Bearer ")
@@ -128,11 +147,10 @@ func (e *Handler) isRootRequest(r *http.Request) bool {
 
 // RequireRootAuth enforces authentication for root/admin endpoints.
 // It accepts either:
-//   - HTTP Basic auth (username "root" + configured root password), for scripts/tools, or
-//   - Bearer JWT issued by HandleUILogin, for the web UI (never stores the raw password).
+//   - HTTP Basic auth (username "root" + configured root password), or
+//   - Bearer JWT issued by HandleUILogin.
 func (e *Handler) RequireRootAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Accept UI Bearer JWT
 		if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
 			raw := strings.TrimPrefix(auth, "Bearer ")
 			tok, err := jwt.ParseWithClaims(raw, &jwt.RegisteredClaims{},
@@ -147,12 +165,18 @@ func (e *Handler) RequireRootAuth(next http.Handler) http.Handler {
 				}
 			}
 		}
-		// Fall back to HTTP Basic auth
 		user, pass, ok := r.BasicAuth()
 		if !ok ||
 			subtle.ConstantTimeCompare([]byte(user), []byte("root")) != 1 ||
 			subtle.ConstantTimeCompare([]byte(pass), []byte(e.RootPassword)) != 1 {
-			w.Header().Set("WWW-Authenticate", `Basic realm="kompakt-root"`)
+			// Only suppress WWW-Authenticate when the client already presented a
+			// Bearer token (e.g. an expired UI JWT). In that case the browser
+			// would pop a native Basic auth dialog before the JS handler can
+			// show the login modal. For requests with no auth or with failed
+			// Basic auth we still advertise the scheme.
+			if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+				w.Header().Set("WWW-Authenticate", `Basic realm="kompakt-root"`)
+			}
 			writeError(w, http.StatusUnauthorized, "invalid root credentials")
 			return
 		}
@@ -192,7 +216,7 @@ func (e *Handler) HandleUILogin(w http.ResponseWriter, r *http.Request) {
 // HandleAgentRegister processes POST /api/v1/register.
 // Agents authenticate with a pre-shared registration secret.
 // Re-registration of the same machine_id is idempotent — the existing agent
-// record is reused and a fresh JWT is issued.
+// record is reused, all previous tokens are revoked, and a fresh token is issued.
 func (e *Handler) HandleAgentRegister(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -211,16 +235,11 @@ func (e *Handler) HandleAgentRegister(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "platform must be one of linux, mac, or windows")
 		return
 	}
-
-	// Validate registration secret using constant-time comparison to prevent
-	// timing-based enumeration of valid secrets.
 	if !e.validRegistrationSecret(req.RegistrationSecret) {
 		writeError(w, http.StatusUnauthorized, "invalid registration secret")
 		return
 	}
 
-	// Reuse existing agent record when the same machine_id re-registers
-	// (e.g., after an OS re-image that cleared the agent state file).
 	var agent *common.Agent
 	machineID := strings.TrimSpace(req.Metadata["machine_id"])
 	if machineID != "" {
@@ -231,6 +250,7 @@ func (e *Handler) HandleAgentRegister(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	isReregistration := agent != nil
 	if agent == nil {
 		agent = &common.Agent{
 			ID:           common.NewID(),
@@ -261,7 +281,13 @@ func (e *Handler) HandleAgentRegister(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to save agent")
 		return
 	}
-	token, err := e.issueToken(agent.ID)
+
+	// On re-registration revoke all existing tokens so only the new one is valid.
+	if isReregistration {
+		_ = e.Store.RevokeAllAgentTokens(agent.ID)
+	}
+
+	token, err := e.issueAgentToken(agent.ID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to issue token")
 		return
@@ -293,8 +319,7 @@ func validPlatform(platform common.PlatformType) bool {
 	}
 }
 
-// requestIP extracts the best-effort client IP from forwarded headers or
-// RemoteAddr.
+// requestIP extracts the best-effort client IP from forwarded headers or RemoteAddr.
 func requestIP(r *http.Request) string {
 	xff := strings.TrimSpace(r.Header.Get("X-Forwarded-For"))
 	if xff != "" {
@@ -306,11 +331,9 @@ func requestIP(r *http.Request) string {
 			}
 		}
 	}
-
 	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
 		return xri
 	}
-
 	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
 	if err == nil {
 		return host
@@ -332,4 +355,3 @@ func GenerateSecret(numBytes int) (string, error) {
 func decodeJSON(r *http.Request, v any) error {
 	return json.NewDecoder(r.Body).Decode(v)
 }
-

--- a/internal/server/handlers/handler.go
+++ b/internal/server/handlers/handler.go
@@ -17,8 +17,7 @@ import (
 // Handler bundles the dependencies shared by all handlers.
 type Handler struct {
 	Store               ports.Store
-	AgentJWTSecret      []byte // signs agent tokens
-	UserJWTSecret       []byte // signs UI session tokens (separate to allow independent rotation)
+	UserJWTSecret       []byte // signs UI session tokens
 	RootPassword        string
 	TokenExpiryHours    int
 	ArtifactsDir        string

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/marko-stanojevic/kompakt/internal/common"
 	"github.com/marko-stanojevic/kompakt/internal/server/handlers"
 	"github.com/marko-stanojevic/kompakt/internal/server/service"
@@ -28,7 +27,6 @@ func newTestEnv(t *testing.T) *handlers.Handler {
 	hub := handlers.NewHub()
 	return &handlers.Handler{
 		Store:            st,
-		AgentJWTSecret:        []byte("test-secret-key-32-bytes-padding!"),
 		RootPassword:     "admin123",
 		TokenExpiryHours: 24,
 		ArtifactsDir:     t.TempDir(),
@@ -1360,26 +1358,16 @@ func TestHandleRegister_InvalidPlatform(t *testing.T) {
 	}
 }
 
-// ── HandleAgentWS: agent not found ───────────────────────────────────────────
+// ── HandleAgentWS: unknown token ─────────────────────────────────────────────
 
-func TestHandleWS_AgentNotFound(t *testing.T) {
+func TestHandleWS_UnknownToken(t *testing.T) {
 	env := newTestEnv(t)
 
-	// Sign a JWT for an agent ID that does not exist in the store.
-	claims := jwt.RegisteredClaims{
-		Subject:   "ghost-agent-id",
-		IssuedAt:  jwt.NewNumericDate(time.Now()),
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
-	}
-	tok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(env.AgentJWTSecret)
-	if err != nil {
-		t.Fatalf("sign token: %v", err)
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws?token="+tok, nil)
+	// A token that was never issued through registration is not in the DB.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws?token=kpkt_notavalidtoken", nil)
 	rr := httptest.NewRecorder()
 	env.HandleAgentWS(rr, req)
-	if rr.Code != http.StatusNotFound {
-		t.Fatalf("status = %d; want 404", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d; want 401", rr.Code)
 	}
 }

--- a/internal/server/handlers/token.go
+++ b/internal/server/handlers/token.go
@@ -1,0 +1,30 @@
+package handlers
+
+import "net/http"
+
+// HandleTokenRefresh handles POST /api/v1/token/refresh.
+// The agent presents its current token; a new token is issued and the old one
+// is revoked atomically. This allows zero-downtime key rotation.
+func (e *Handler) HandleTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	agentID := r.Header.Get("X-Agent-ID")
+	oldRaw := rawTokenFromRequest(r)
+
+	newRaw, err := e.issueAgentToken(agentID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to issue token")
+		return
+	}
+
+	// Revoke the old token after the new one is safely stored.
+	if oldRaw != "" {
+		if tok, err := e.Store.GetAgentTokenByHash(sha256hex(oldRaw)); err == nil {
+			_ = e.Store.RevokeAgentToken(tok.ID)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"token": newRaw})
+}

--- a/internal/server/handlers/token_test.go
+++ b/internal/server/handlers/token_test.go
@@ -1,0 +1,290 @@
+package handlers_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marko-stanojevic/kompakt/internal/common"
+)
+
+// sha256hex mirrors the private helper in auth.go for test use.
+func sha256hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// ── HandleTokenRefresh ────────────────────────────────────────────────────────
+
+func TestHandleTokenRefresh_NewTokenIssuedOldRevoked(t *testing.T) {
+	env := newTestEnv(t)
+	agentID, oldToken := registerAgent(t, env, "SN-REFRESH-01", "refresh-host")
+
+	// RequireAgentAuth sets X-Agent-ID; simulate that here.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/token/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+oldToken)
+	req.Header.Set("X-Agent-ID", agentID)
+	rr := httptest.NewRecorder()
+	env.HandleTokenRefresh(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	resp := decode[map[string]string](t, rr)
+	newToken := resp["token"]
+	if newToken == "" {
+		t.Fatal("expected non-empty token in response")
+	}
+	if !strings.HasPrefix(newToken, "kpkt_") {
+		t.Errorf("new token = %q; want kpkt_ prefix", newToken)
+	}
+	if newToken == oldToken {
+		t.Error("new token must differ from the old token")
+	}
+}
+
+func TestHandleTokenRefresh_OldTokenRejectedAfterRotation(t *testing.T) {
+	env := newTestEnv(t)
+	agentID, oldToken := registerAgent(t, env, "SN-REFRESH-02", "refresh-host-2")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/token/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+oldToken)
+	req.Header.Set("X-Agent-ID", agentID)
+	rr := httptest.NewRecorder()
+	env.HandleTokenRefresh(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("refresh status = %d; want 200", rr.Code)
+	}
+	newToken := decode[map[string]string](t, rr)["token"]
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	// Old token must now be rejected.
+	oldReq := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	oldReq.Header.Set("Authorization", "Bearer "+oldToken)
+	oldRR := httptest.NewRecorder()
+	env.RequireAgentAuth(okHandler).ServeHTTP(oldRR, oldReq)
+	if oldRR.Code != http.StatusUnauthorized {
+		t.Errorf("old token: status = %d; want 401 after rotation", oldRR.Code)
+	}
+
+	// New token must be accepted.
+	newReq := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	newReq.Header.Set("Authorization", "Bearer "+newToken)
+	newRR := httptest.NewRecorder()
+	env.RequireAgentAuth(okHandler).ServeHTTP(newRR, newReq)
+	if newRR.Code != http.StatusOK {
+		t.Errorf("new token: status = %d; want 200", newRR.Code)
+	}
+}
+
+func TestHandleTokenRefresh_MethodNotAllowed(t *testing.T) {
+	env := newTestEnv(t)
+	rr := getRequest(t, env.HandleTokenRefresh, "/api/v1/token/refresh", "")
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d; want 405", rr.Code)
+	}
+}
+
+// ── Opaque token format ───────────────────────────────────────────────────────
+
+func TestHandleRegister_TokenHasKpktPrefix(t *testing.T) {
+	env := newTestEnv(t)
+	_, token := registerAgent(t, env, "SN-PREFIX-01", "prefix-host")
+	if !strings.HasPrefix(token, "kpkt_") {
+		t.Errorf("token = %q; want kpkt_ prefix", token)
+	}
+	// 5 (prefix) + 64 (32 bytes hex-encoded) = 69 chars
+	if len(token) != 69 {
+		t.Errorf("token length = %d; want 69 (kpkt_ + 64 hex chars)", len(token))
+	}
+}
+
+// ── Opaque token auth scenarios ──────────────────────────────────────────────
+
+func TestRequireAgentAuth_RevokedTokenRejected(t *testing.T) {
+	env := newTestEnv(t)
+	agentID, token := registerAgent(t, env, "SN-REVOKE-01", "revoke-host")
+
+	// Revoke the token directly via the store.
+	tok, err := env.Store.GetAgentTokenByHash(sha256hex(token))
+	if err != nil {
+		t.Fatalf("GetAgentTokenByHash: %v", err)
+	}
+	if err := env.Store.RevokeAgentToken(tok.ID); err != nil {
+		t.Fatalf("RevokeAgentToken: %v", err)
+	}
+	_ = agentID
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	env.RequireAgentAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("revoked token: status = %d; want 401", rr.Code)
+	}
+}
+
+func TestRequireAgentAuth_ExpiredTokenRejected(t *testing.T) {
+	env := newTestEnv(t)
+	agentID, _ := registerAgent(t, env, "SN-EXPIRED-01", "expired-host")
+
+	// Insert an already-expired token directly into the store.
+	rawToken := "kpkt_" + strings.Repeat("e", 64)
+	pastExpiry := time.Now().Add(-1 * time.Hour)
+	_ = env.Store.CreateAgentToken(&common.AgentToken{
+		ID:        "tok-expired",
+		AgentID:   agentID,
+		TokenHash: sha256hex(rawToken),
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: &pastExpiry,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	rr := httptest.NewRecorder()
+	env.RequireAgentAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expired token: status = %d; want 401", rr.Code)
+	}
+}
+
+func TestRequireAgentAuth_ValidTokenUpdatesAgentStatus(t *testing.T) {
+	env := newTestEnv(t)
+	agentID, token := registerAgent(t, env, "SN-STATUS-01", "status-host")
+
+	// Set agent to offline so we can verify the transition.
+	a, ok := env.Store.GetAgent(agentID)
+	if !ok {
+		t.Fatal("agent not found")
+	}
+	a.Status = common.AgentStatusOffline
+	if err := env.Store.SaveAgent(a); err != nil {
+		t.Fatalf("SaveAgent: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	env.RequireAgentAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rr.Code)
+	}
+	updated, ok := env.Store.GetAgent(agentID)
+	if !ok {
+		t.Fatal("agent not found after auth")
+	}
+	if updated.Status == common.AgentStatusOffline {
+		t.Error("expected agent status to change from Offline after successful auth")
+	}
+}
+
+// ── RequireRootAuth — WWW-Authenticate behaviour ──────────────────────────────
+
+func TestRequireRootAuth_WWWAuthenticateOnlyWhenNoAuthHeader(t *testing.T) {
+	env := newTestEnv(t)
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("no Authorization header — WWW-Authenticate is set", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+		rr := httptest.NewRecorder()
+		env.RequireRootAuth(okHandler).ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d; want 401", rr.Code)
+		}
+		if got := rr.Header().Get("WWW-Authenticate"); got == "" {
+			t.Error("expected WWW-Authenticate header when no auth is provided")
+		}
+	})
+
+	t.Run("expired Bearer token — no WWW-Authenticate header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+		req.Header.Set("Authorization", "Bearer kpkt_expiredorinvalidtoken000000000000000000000000000000000000000000")
+		rr := httptest.NewRecorder()
+		env.RequireRootAuth(okHandler).ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d; want 401", rr.Code)
+		}
+		if got := rr.Header().Get("WWW-Authenticate"); got != "" {
+			t.Errorf("WWW-Authenticate = %q; want empty when Bearer token was already presented", got)
+		}
+	})
+
+	t.Run("wrong Basic auth credentials — WWW-Authenticate is set", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+		req.SetBasicAuth("root", "wrong-password")
+		rr := httptest.NewRecorder()
+		env.RequireRootAuth(okHandler).ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("status = %d; want 401", rr.Code)
+		}
+		// Basic auth requests do not have a Bearer header; WWW-Authenticate should be sent.
+		if got := rr.Header().Get("WWW-Authenticate"); got == "" {
+			t.Error("expected WWW-Authenticate header on failed Basic auth")
+		}
+	})
+}
+
+// ── Re-registration revokes old tokens ───────────────────────────────────────
+
+func TestHandleRegister_ReregistrationRevokesOldTokens(t *testing.T) {
+	env := newTestEnv(t)
+	agentID, oldToken := registerAgent(t, env, "SN-REREG-01", "rereg-host")
+
+	// Verify old token works.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	req.Header.Set("Authorization", "Bearer "+oldToken)
+	rr := httptest.NewRecorder()
+	env.RequireAgentAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("old token before re-registration: status = %d; want 200", rr.Code)
+	}
+
+	// Re-register the same machine.
+	_, newToken := registerAgent(t, env, "SN-REREG-01", "rereg-host")
+	_ = agentID
+
+	if newToken == oldToken {
+		t.Fatal("expected a different token after re-registration")
+	}
+
+	// Old token must now be rejected.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	req2.Header.Set("Authorization", "Bearer "+oldToken)
+	rr2 := httptest.NewRecorder()
+	env.RequireAgentAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusUnauthorized {
+		t.Errorf("old token after re-registration: status = %d; want 401", rr2.Code)
+	}
+
+	// New token must be accepted.
+	req3 := httptest.NewRequest(http.MethodGet, "/api/v1/ws", nil)
+	req3.Header.Set("Authorization", "Bearer "+newToken)
+	rr3 := httptest.NewRecorder()
+	env.RequireAgentAuth(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr3, req3)
+	if rr3.Code != http.StatusOK {
+		t.Errorf("new token after re-registration: status = %d; want 200", rr3.Code)
+	}
+}

--- a/internal/server/handlers/ui/assets/style.css
+++ b/internal/server/handlers/ui/assets/style.css
@@ -9,10 +9,12 @@ nav{display:flex;gap:0;align-items:stretch;margin-left:8px}
 nav a{color:#8b949e;text-decoration:none;padding:0 14px;display:flex;align-items:center;font-size:.875rem;border-bottom:2px solid transparent;transition:color .15s,border-color .15s;white-space:nowrap}
 nav a:hover{color:#e6edf3}
 nav a.active{color:#e6edf3;border-bottom-color:#f78166}
-.badge{display:inline-block;font-size:0.75rem;padding:1px 8px;border-radius:12px;border:1px solid transparent;font-weight:500;line-height:1.4}
+.badge{display:inline-block;font-size:0.82rem;padding:3px 10px;border-radius:12px;border:1px solid transparent;font-weight:500;line-height:1.4}
 .badge-muted{background:#21262d;color:#8b949e;border-color:#30363d}
+.badge-info{background:rgba(31,111,235,0.15);color:#58a6ff;border-color:rgba(31,111,235,0.4)}
 .badge-success{background:rgba(35,134,54,0.15);color:#3fb950;border-color:rgba(35,134,54,0.4)}
 .badge-warning{background:rgba(158,106,3,0.15);color:#e3b341;border-color:rgba(158,106,3,0.4)}
+.badge-danger{background:rgba(218,54,51,0.15);color:#f85149;border-color:rgba(218,54,51,0.4)}
 .badge-outline{background:transparent !important;border-color:#30363d !important;color:#8b949e !important}
 .header-right{margin-left:auto;display:flex;align-items:center}
 .btn-signout{background:transparent;border:1px solid #30363d;color:#8b949e;padding:4px 12px;border-radius:6px;font-size:.8125rem;cursor:pointer;transition:color .15s,border-color .15s}
@@ -94,14 +96,13 @@ nav a.active{color:#e6edf3;border-bottom-color:#f78166}
 .empty{text-align:center;color:#8b949e;padding:60px 20px}
 
 /* Pills (Statuses) */
-.pill{display:inline-flex;align-items:center;gap:6px;font-size:.82rem;padding:3px 10px;border-radius:12px;font-weight:500}
+.pill{display:inline-block;font-size:.85rem;padding:4px 11px;border-radius:12px;font-weight:500}
 .pill.running{background:#1f6feb33;color:#58a6ff}
-.pill.done{background:#23863633;color:#3fb950}
+.pill.completed{background:#23863633;color:#3fb950}
 .pill.failed{background:#da363333;color:#f85149}
 .pill.rebooting{background:#9e6a0333;color:#e3b341}
 .pill.pending,.pill.registered,.pill.offline{background:#21262d;color:#8b949e}
 .pill.connected,.pill.deploying{background:#1f6feb22;color:#79c0ff}
-.dot{width:7px;height:7px;border-radius:50%;background:currentColor}
 
 /* Buttons */
 button{background:#21262d;border:1px solid #30363d;color:#e6edf3;padding:6px 12px;border-radius:6px;cursor:pointer;font-size:.85rem}

--- a/internal/server/handlers/ui/templates/partials/agents-table.html
+++ b/internal/server/handlers/ui/templates/partials/agents-table.html
@@ -25,7 +25,7 @@
       <div style="color:#8b949e">{{or .Vendor "-"}}</div>
     </div>
     <div class="mono">{{or .IPAddress "-"}}</div>
-    <div><span class="pill {{statusClass .StatusStr}}"><span class="dot"></span>{{or .StatusStr "-"}}</span></div>
+    <div><span class="pill {{.StatusStr}}">{{or (statusLabel .StatusStr) "-"}}</span></div>
     <div>
       <div>{{formatTime .LastActivityAt}}</div>
       <div class="sub">Step: {{.DeployStep}}</div>

--- a/internal/server/handlers/ui/templates/partials/deployments-table.html
+++ b/internal/server/handlers/ui/templates/partials/deployments-table.html
@@ -22,7 +22,7 @@
       <div>{{or .PlaybookName "-"}}</div>
       <div class="sub mono">{{.PlaybookID}}</div>
     </div>
-    <div><span class="badge badge-{{statusClass (print .Status)}}">{{.Status}}</span></div>
+    <div><span class="badge badge-{{statusClass (print .Status)}}">{{statusLabel (print .Status)}}</span></div>
     <div>{{formatTime .UpdatedAt}}</div>
     <div>{{formatTimePtr .FinishedAt}}</div>
     <div class="card-top-right"><div class="card-menu">

--- a/internal/server/handlers/ui_templates.go
+++ b/internal/server/handlers/ui_templates.go
@@ -140,18 +140,26 @@ var tmplFuncs = template.FuncMap{
 			return strconv.FormatInt(n, 10) + " B"
 		}
 	},
+	"statusLabel": func(s string) string {
+		switch strings.ToLower(s) {
+		case "completed":
+			return "completed"
+		case "failed":
+			return "failed"
+		default:
+			return s
+		}
+	},
 	"statusClass": func(s string) string {
 		switch strings.ToLower(s) {
-		case "done":
+		case "completed":
 			return "success"
 		case "failed":
-			return "warning"
-		case "running":
-			return "success"
+			return "danger"
+		case "running", "connected", "deploying":
+			return "info"
 		case "rebooting":
 			return "warning"
-		case "connected", "deploying":
-			return "success"
 		default:
 			return "muted"
 		}
@@ -348,7 +356,6 @@ func (e *Handler) HandlePartialAgents(w http.ResponseWriter, r *http.Request) {
 		status := string(a.Status)
 		if dep, ok := depByAgent[a.ID]; ok {
 			step = "#" + strconv.Itoa(dep.ResumeStepIndex)
-			status = string(dep.Status)
 		}
 		rows[i] = agentRow{Agent: a, DeployStep: step, StatusStr: status}
 	}

--- a/internal/server/handlers/ws.go
+++ b/internal/server/handlers/ws.go
@@ -221,11 +221,11 @@ func (e *Handler) handleWSMessage(agentID string, data []byte) {
 		slog.Info("playbook completed", "agent_id", agentID, "deployment_id", d.DeploymentID, "playbook", playbookName)
 		now := time.Now()
 		e.updateDeploy(d.DeploymentID, func(dep *common.DeploymentState) {
-			dep.Status = common.DeploymentStatusDone
+			dep.Status = common.DeploymentStatusCompleted
 			dep.FinishedAt = &now
 		})
 		if a, ok := e.Store.GetAgent(agentID); ok {
-			a.Status = common.AgentStatusDone
+			a.Status = common.AgentStatusCompleted
 			_ = e.Store.SaveAgent(a)
 		}
 

--- a/internal/server/handlers/ws_internal_test.go
+++ b/internal/server/handlers/ws_internal_test.go
@@ -111,12 +111,12 @@ func TestHandleWSMessage_LogAndLifecycleUpdates(t *testing.T) {
 
 	sendWS(t, e, "c1", common.WSMsgDeployDone, common.WSStepData{DeploymentID: "dep-1"})
 	dep, _ = e.Store.GetDeployment("dep-1")
-	if dep.Status != common.DeploymentStatusDone || dep.FinishedAt == nil {
+	if dep.Status != common.DeploymentStatusCompleted || dep.FinishedAt == nil {
 		t.Fatalf("after deploy_done: status=%q finished_at_nil=%v", dep.Status, dep.FinishedAt == nil)
 	}
 	agent, _ := e.Store.GetAgent("c1")
-	if agent.Status != common.AgentStatusDone {
-		t.Fatalf("agent status = %q; want %q", agent.Status, common.AgentStatusDone)
+	if agent.Status != common.AgentStatusCompleted {
+		t.Fatalf("agent status = %q; want %q", agent.Status, common.AgentStatusCompleted)
 	}
 }
 

--- a/internal/server/integration_helpers_test.go
+++ b/internal/server/integration_helpers_test.go
@@ -39,7 +39,6 @@ func newIntegrationEnv(t *testing.T) *integrationEnv {
 	hub := handlers.NewHub()
 	h := &handlers.Handler{
 		Store:               st,
-		AgentJWTSecret:      []byte("agent-secret-32-bytes-padding!!!"),
 		UserJWTSecret:       []byte("user-secret-32-bytes-padding!!!!"),
 		RootPassword:        intTestRootPassword,
 		TokenExpiryHours:    24,
@@ -101,7 +100,7 @@ func basicAuthHeader(password string) string {
 	return req.Header.Get("Authorization")
 }
 
-// registerAgent registers a test agent and returns its JWT.
+// registerAgent registers a test agent and returns its opaque token.
 func (e *integrationEnv) registerAgent(t *testing.T, hostname string) string {
 	t.Helper()
 	body, _ := json.Marshal(common.RegistrationRequest{

--- a/internal/server/integration_token_test.go
+++ b/internal/server/integration_token_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// ── Token lifecycle ───────────────────────────────────────────────────────────
+
+func TestIntegration_TokenRefresh_NewTokenWorks(t *testing.T) {
+	env := newIntegrationEnv(t)
+	oldToken := env.registerAgent(t, "refresh-host")
+
+	// Call /api/v1/token/refresh with the current token.
+	req, _ := http.NewRequest(http.MethodPost, env.srv.URL+"/api/v1/token/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+oldToken)
+	resp, err := env.client.Do(req)
+	if err != nil {
+		t.Fatalf("token/refresh: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("token/refresh status = %d; body = %s", resp.StatusCode, b)
+	}
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode refresh response: %v", err)
+	}
+	if result.Token == "" {
+		t.Fatal("expected non-empty token in refresh response")
+	}
+	if result.Token == oldToken {
+		t.Error("refreshed token must differ from the original")
+	}
+}
+
+func TestIntegration_TokenRefresh_OldTokenInvalidated(t *testing.T) {
+	env := newIntegrationEnv(t)
+	oldToken := env.registerAgent(t, "refresh-host-2")
+
+	// Rotate the token.
+	req, _ := http.NewRequest(http.MethodPost, env.srv.URL+"/api/v1/token/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+oldToken)
+	resp, err := env.client.Do(req)
+	if err != nil {
+		t.Fatalf("token/refresh: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("token/refresh status = %d; body = %s", resp.StatusCode, b)
+	}
+
+	// The old token must now be rejected on a protected endpoint.
+	wsReq, _ := http.NewRequest(http.MethodGet, env.srv.URL+"/api/v1/ws?token="+oldToken, nil)
+	wsResp, err := env.client.Do(wsReq)
+	if err != nil {
+		t.Fatalf("ws with old token: %v", err)
+	}
+	defer wsResp.Body.Close()
+	if wsResp.StatusCode == http.StatusSwitchingProtocols {
+		t.Error("old token should be rejected after rotation")
+	}
+	// Expect 401 (bad/revoked token before WebSocket upgrade).
+	if wsResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("old token: status = %d; want 401", wsResp.StatusCode)
+	}
+}
+
+func TestIntegration_TokenRefresh_RequiresAuth(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	req, _ := http.NewRequest(http.MethodPost, env.srv.URL+"/api/v1/token/refresh", nil)
+	resp, err := env.client.Do(req)
+	if err != nil {
+		t.Fatalf("token/refresh no auth: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401 when no auth provided", resp.StatusCode)
+	}
+}
+
+func TestIntegration_TokenRefresh_MethodNotAllowed(t *testing.T) {
+	env := newIntegrationEnv(t)
+	token := env.registerAgent(t, "refresh-method-host")
+
+	req, _ := http.NewRequest(http.MethodGet, env.srv.URL+"/api/v1/token/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := env.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET token/refresh: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d; want 405", resp.StatusCode)
+	}
+}
+
+// ── Re-registration revokes old tokens ───────────────────────────────────────
+
+func TestIntegration_Reregistration_RevokesOldToken(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	// Register the same machine twice (same hostname, no machine_id — treated as two separate agents in integration env).
+	// For the revocation test, register first, then register again with the same machine_id.
+	body1, _ := json.Marshal(map[string]any{
+		"platform":            "linux",
+		"hostname":            "reregister-host",
+		"registration_secret": intTestRegSecret,
+		"metadata":            map[string]string{"machine_id": "test-machine-abc"},
+	})
+	resp1, err := env.client.Post(env.srv.URL+"/api/v1/register", "application/json", bytes.NewReader(body1))
+	if err != nil {
+		t.Fatalf("register 1: %v", err)
+	}
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("register 1 status = %d; body = %s", resp1.StatusCode, b)
+	}
+	var reg1 struct {
+		Token string `json:"token"`
+	}
+	json.NewDecoder(resp1.Body).Decode(&reg1)
+	if reg1.Token == "" {
+		t.Fatal("first registration returned empty token")
+	}
+
+	// Second registration for the same machine_id.
+	body2, _ := json.Marshal(map[string]any{
+		"platform":            "linux",
+		"hostname":            "reregister-host",
+		"registration_secret": intTestRegSecret,
+		"metadata":            map[string]string{"machine_id": "test-machine-abc"},
+	})
+	resp2, err := env.client.Post(env.srv.URL+"/api/v1/register", "application/json", bytes.NewReader(body2))
+	if err != nil {
+		t.Fatalf("register 2: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("register 2 status = %d; body = %s", resp2.StatusCode, b)
+	}
+
+	// Old token must now be rejected.
+	wsReq, _ := http.NewRequest(http.MethodGet, env.srv.URL+"/api/v1/ws?token="+reg1.Token, nil)
+	wsResp, err := env.client.Do(wsReq)
+	if err != nil {
+		t.Fatalf("ws with old token: %v", err)
+	}
+	defer wsResp.Body.Close()
+	if wsResp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("old token after re-registration: status = %d; want 401", wsResp.StatusCode)
+	}
+}
+
+// ── WWW-Authenticate behaviour ────────────────────────────────────────────────
+
+func TestIntegration_RootAPI_BearerExpired_NoWWWAuthenticate(t *testing.T) {
+	env := newIntegrationEnv(t)
+
+	// Send a clearly invalid Bearer token (simulates an expired UI JWT).
+	resp := env.get(t, "/api/v1/status", "Bearer invalid-token-here")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d; want 401", resp.StatusCode)
+	}
+	if got := resp.Header.Get("WWW-Authenticate"); got != "" {
+		t.Errorf("WWW-Authenticate = %q; want empty when Bearer token was already presented", got)
+	}
+}
+
+func TestIntegration_RootAPI_NoAuth_HasWWWAuthenticate(t *testing.T) {
+	env := newIntegrationEnv(t)
+	resp := env.get(t, "/api/v1/status", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d; want 401", resp.StatusCode)
+	}
+	const wantHeader = `Basic realm="kompakt-root"`
+	if got := resp.Header.Get("WWW-Authenticate"); got != wantHeader {
+		t.Errorf("WWW-Authenticate = %q; want %q", got, wantHeader)
+	}
+}

--- a/internal/server/ports/store.go
+++ b/internal/server/ports/store.go
@@ -39,6 +39,11 @@ type Store interface {
 	AppendLogs(entries []*common.LogEntry) error
 	GetLogsForDeployment(deploymentID string) []*common.LogEntry
 	GetLogsForAgent(agentID string) []*common.LogEntry
+
+	CreateAgentToken(t *common.AgentToken) error
+	GetAgentTokenByHash(hash string) (*common.AgentToken, error)
+	RevokeAgentToken(id string) error
+	RevokeAllAgentTokens(agentID string) error
 }
 
 // Hub defines websocket coordination capabilities used by services.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,8 +28,11 @@ func NewServer(env *handlers.Handler) http.Handler {
 	// POST /api/v1/ui/login — no auth; validates root password, returns short-lived UI JWT
 	mux.HandleFunc("/api/v1/ui/login", env.HandleUILogin)
 
-	// GET  /api/v1/ws        — WebSocket; JWT via ?token= query param
+	// GET  /api/v1/ws             — WebSocket; token via ?token= query param
 	mux.Handle("/api/v1/ws", http.HandlerFunc(env.HandleAgentWS))
+
+	// POST /api/v1/token/refresh — agent token rotation (requires agent auth)
+	mux.Handle("/api/v1/token/refresh", env.RequireAgentAuth(http.HandlerFunc(env.HandleTokenRefresh)))
 
 	// ── Root API (HTTP Basic auth) ───────────────────────────────────────────
 	root := env.RequireRootAuth

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,13 +2,14 @@ package server
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/marko-stanojevic/kompakt/internal/common"
 	"github.com/marko-stanojevic/kompakt/internal/server/handlers"
 	"github.com/marko-stanojevic/kompakt/internal/server/service"
 	"github.com/marko-stanojevic/kompakt/internal/server/store"
@@ -61,7 +62,6 @@ func newServerTestEnv(t *testing.T) *handlers.Handler {
 	hub := handlers.NewHub()
 	return &handlers.Handler{
 		Store:               st,
-		AgentJWTSecret:           []byte("test-jwt-secret-32-bytes-padding!"),
 		RootPassword:        "admin123",
 		TokenExpiryHours:    24,
 		ArtifactsDir:        t.TempDir(),
@@ -103,19 +103,25 @@ func TestDualAuth_BasicAndBearer(t *testing.T) {
 		t.Fatalf("basic auth status = %d; want 204", basicRR.Code)
 	}
 
-	// Bearer auth path.
-	claims := jwt.RegisteredClaims{
-		Subject:   "client-1",
-		IssuedAt:  jwt.NewNumericDate(time.Now()),
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	// Bearer auth path — register an agent to obtain a valid opaque token.
+	regBody, _ := json.Marshal(common.RegistrationRequest{
+		Platform:           common.PlatformLinux,
+		Hostname:           "test-host",
+		RegistrationSecret: "reg-secret",
+	})
+	regReq := httptest.NewRequest(http.MethodPost, "/api/v1/register", bytes.NewReader(regBody))
+	regReq.Header.Set("Content-Type", "application/json")
+	regRR := httptest.NewRecorder()
+	env.HandleAgentRegister(regRR, regReq)
+	if regRR.Code != http.StatusOK {
+		t.Fatalf("register status = %d; want 200", regRR.Code)
 	}
-	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	raw, err := tok.SignedString(env.AgentJWTSecret)
-	if err != nil {
-		t.Fatalf("signed token: %v", err)
+	var regResp common.RegistrationResponse
+	if err := json.NewDecoder(regRR.Body).Decode(&regResp); err != nil {
+		t.Fatalf("decode register response: %v", err)
 	}
 	bearerReq := httptest.NewRequest(http.MethodGet, "/artifacts", nil)
-	bearerReq.Header.Set("Authorization", "Bearer "+raw)
+	bearerReq.Header.Set("Authorization", "Bearer "+regResp.Token)
 	bearerRR := httptest.NewRecorder()
 	h.ServeHTTP(bearerRR, bearerReq)
 	if bearerRR.Code != http.StatusNoContent {

--- a/internal/server/service/manager_test.go
+++ b/internal/server/service/manager_test.go
@@ -194,7 +194,7 @@ func TestPushPlaybookIfAssignedSkipsCompleted(t *testing.T) {
 		ID:         "dep-done",
 		AgentID:    "c1",
 		PlaybookID: "pb-1",
-		Status:     common.DeploymentStatusDone,
+		Status:     common.DeploymentStatusCompleted,
 		StartedAt:  now.Add(-time.Hour),
 		FinishedAt: &now,
 	})

--- a/internal/server/store/agent_token_test.go
+++ b/internal/server/store/agent_token_test.go
@@ -1,0 +1,227 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marko-stanojevic/kompakt/internal/common"
+	"github.com/marko-stanojevic/kompakt/internal/server/store"
+)
+
+// agentForToken inserts a minimal agent row so FK constraints are satisfied.
+func agentForToken(t *testing.T, s *store.Store, id string) {
+	t.Helper()
+	now := time.Now()
+	if err := s.SaveAgent(&common.Agent{
+		ID:             id,
+		Hostname:       id,
+		Status:         common.AgentStatusRegistered,
+		RegisteredAt:   now,
+		LastActivityAt: now,
+	}); err != nil {
+		t.Fatalf("SaveAgent(%s): %v", id, err)
+	}
+}
+
+// ── CreateAgentToken / GetAgentTokenByHash ─────────────────────────────────
+
+func TestAgentTokenCRUD(t *testing.T) {
+	s := newTestStore(t)
+	agentForToken(t, s, "a1")
+
+	exp := time.Now().Add(24 * time.Hour)
+	tok := &common.AgentToken{
+		ID:        "tok-1",
+		AgentID:   "a1",
+		TokenHash: "sha256hashvalue",
+		CreatedAt: time.Now(),
+		ExpiresAt: &exp,
+	}
+	if err := s.CreateAgentToken(tok); err != nil {
+		t.Fatalf("CreateAgentToken: %v", err)
+	}
+
+	got, err := s.GetAgentTokenByHash("sha256hashvalue")
+	if err != nil {
+		t.Fatalf("GetAgentTokenByHash: %v", err)
+	}
+	if got.ID != "tok-1" {
+		t.Errorf("ID = %q; want tok-1", got.ID)
+	}
+	if got.AgentID != "a1" {
+		t.Errorf("AgentID = %q; want a1", got.AgentID)
+	}
+	if got.RevokedAt != nil {
+		t.Error("expected RevokedAt to be nil on fresh token")
+	}
+	if got.ExpiresAt == nil {
+		t.Error("expected ExpiresAt to be persisted")
+	}
+}
+
+func TestAgentToken_UnknownHashReturnsError(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.GetAgentTokenByHash("nonexistent-hash"); err == nil {
+		t.Error("expected error for unknown hash; got nil")
+	}
+}
+
+// ── RevokeAgentToken ────────────────────────────────────────────────────────
+
+func TestAgentToken_Revoke(t *testing.T) {
+	s := newTestStore(t)
+	agentForToken(t, s, "a2")
+
+	tok := &common.AgentToken{
+		ID:        "tok-2",
+		AgentID:   "a2",
+		TokenHash: "hash-revoke",
+		CreatedAt: time.Now(),
+	}
+	if err := s.CreateAgentToken(tok); err != nil {
+		t.Fatalf("CreateAgentToken: %v", err)
+	}
+
+	if err := s.RevokeAgentToken("tok-2"); err != nil {
+		t.Fatalf("RevokeAgentToken: %v", err)
+	}
+
+	got, err := s.GetAgentTokenByHash("hash-revoke")
+	if err != nil {
+		t.Fatalf("GetAgentTokenByHash after revoke: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Error("expected RevokedAt to be set after revocation")
+	}
+}
+
+// ── RevokeAllAgentTokens ────────────────────────────────────────────────────
+
+func TestAgentToken_RevokeAll(t *testing.T) {
+	s := newTestStore(t)
+	agentForToken(t, s, "a3")
+
+	hashes := []string{"hash-all-a", "hash-all-b", "hash-all-c"}
+	for i, h := range hashes {
+		tok := &common.AgentToken{
+			ID:        "tok-all-" + string(rune('a'+i)),
+			AgentID:   "a3",
+			TokenHash: h,
+			CreatedAt: time.Now(),
+		}
+		if err := s.CreateAgentToken(tok); err != nil {
+			t.Fatalf("CreateAgentToken(%s): %v", h, err)
+		}
+	}
+
+	if err := s.RevokeAllAgentTokens("a3"); err != nil {
+		t.Fatalf("RevokeAllAgentTokens: %v", err)
+	}
+
+	for _, h := range hashes {
+		got, err := s.GetAgentTokenByHash(h)
+		if err != nil {
+			t.Errorf("GetAgentTokenByHash(%s): %v", h, err)
+			continue
+		}
+		if got.RevokedAt == nil {
+			t.Errorf("token %s: expected RevokedAt to be set after RevokeAll", h)
+		}
+	}
+}
+
+func TestAgentToken_RevokeAllOnlyAffectsTargetAgent(t *testing.T) {
+	s := newTestStore(t)
+	agentForToken(t, s, "a4")
+	agentForToken(t, s, "a5")
+
+	_ = s.CreateAgentToken(&common.AgentToken{ID: "tok-a4", AgentID: "a4", TokenHash: "hash-a4", CreatedAt: time.Now()})
+	_ = s.CreateAgentToken(&common.AgentToken{ID: "tok-a5", AgentID: "a5", TokenHash: "hash-a5", CreatedAt: time.Now()})
+
+	if err := s.RevokeAllAgentTokens("a4"); err != nil {
+		t.Fatalf("RevokeAllAgentTokens(a4): %v", err)
+	}
+
+	// a4's token should be revoked.
+	got4, _ := s.GetAgentTokenByHash("hash-a4")
+	if got4.RevokedAt == nil {
+		t.Error("a4 token: expected RevokedAt to be set")
+	}
+
+	// a5's token must remain untouched.
+	got5, _ := s.GetAgentTokenByHash("hash-a5")
+	if got5.RevokedAt != nil {
+		t.Error("a5 token: should not be revoked when revoking a4's tokens")
+	}
+}
+
+// ── ON DELETE CASCADE ────────────────────────────────────────────────────────
+
+func TestAgentToken_DeleteAgentCascade(t *testing.T) {
+	s := newTestStore(t)
+	agentForToken(t, s, "a6")
+
+	_ = s.CreateAgentToken(&common.AgentToken{
+		ID:        "tok-cascade",
+		AgentID:   "a6",
+		TokenHash: "hash-cascade",
+		CreatedAt: time.Now(),
+	})
+
+	if _, err := s.GetAgentTokenByHash("hash-cascade"); err != nil {
+		t.Fatalf("token should exist before agent delete: %v", err)
+	}
+
+	if err := s.DeleteAgent("a6"); err != nil {
+		t.Fatalf("DeleteAgent: %v", err)
+	}
+
+	if _, err := s.GetAgentTokenByHash("hash-cascade"); err == nil {
+		t.Error("expected token to be deleted with agent (ON DELETE CASCADE); got nil error")
+	}
+}
+
+// ── Persistence across reopen ────────────────────────────────────────────────
+
+func TestAgentToken_Persistence(t *testing.T) {
+	dir := t.TempDir()
+
+	s1, err := store.New(dir, "")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	now := time.Now()
+	_ = s1.SaveAgent(&common.Agent{ID: "a7", Hostname: "h", Status: common.AgentStatusRegistered, RegisteredAt: now, LastActivityAt: now})
+	exp := now.Add(24 * time.Hour)
+	_ = s1.CreateAgentToken(&common.AgentToken{
+		ID:        "tok-persist",
+		AgentID:   "a7",
+		TokenHash: "hash-persist",
+		CreatedAt: now,
+		ExpiresAt: &exp,
+	})
+	_ = s1.Close()
+
+	s2, err := store.New(dir, "")
+	if err != nil {
+		t.Fatalf("store.New (reopen): %v", err)
+	}
+	t.Cleanup(func() { _ = s2.Close() })
+
+	got, err := s2.GetAgentTokenByHash("hash-persist")
+	if err != nil {
+		t.Fatalf("GetAgentTokenByHash after reopen: %v", err)
+	}
+	if got.ID != "tok-persist" {
+		t.Errorf("ID = %q; want tok-persist", got.ID)
+	}
+	if got.AgentID != "a7" {
+		t.Errorf("AgentID = %q; want a7", got.AgentID)
+	}
+	if got.ExpiresAt == nil {
+		t.Error("ExpiresAt should be persisted across reopen")
+	}
+	if got.RevokedAt != nil {
+		t.Error("RevokedAt should be nil on freshly created token")
+	}
+}

--- a/internal/server/store/store.go
+++ b/internal/server/store/store.go
@@ -96,6 +96,17 @@ CREATE TABLE IF NOT EXISTS logs (
     timestamp     TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_logs_deployment_id ON logs (deployment_id);
+
+CREATE TABLE IF NOT EXISTS agent_tokens (
+    id         TEXT PRIMARY KEY,
+    agent_id   TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL,
+    expires_at TEXT,
+    revoked_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_agent_tokens_hash     ON agent_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS idx_agent_tokens_agent_id ON agent_tokens (agent_id);
 `
 
 // New opens (or creates) the SQLite store at dir/kompakt.db.
@@ -111,6 +122,13 @@ func New(dir string, _ string) (*Store, error) {
 		return nil, fmt.Errorf("opening sqlite: %w", err)
 	}
 	db.SetMaxOpenConns(1)
+	// Enforce foreign key constraints and cascades. This must be executed after
+	// every new connection is opened; the DSN parameter alone is not reliable
+	// across all SQLite driver versions.
+	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("enabling foreign keys: %w", err)
+	}
 	if _, err := db.Exec(schema); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("applying schema: %w", err)
@@ -121,6 +139,9 @@ func New(dir string, _ string) (*Store, error) {
 	} {
 		_, _ = db.Exec(m)
 	}
+	// Data migrations: rename status values for consistency.
+	_, _ = db.Exec(`UPDATE agents      SET status = 'completed' WHERE status = 'done'`)
+	_, _ = db.Exec(`UPDATE deployments SET status = 'completed' WHERE status = 'done'`)
 	return &Store{db: db}, nil
 }
 
@@ -691,3 +712,46 @@ func scanLogs(rows *sql.Rows) []*common.LogEntry {
 	return out
 }
 
+// ── Agent tokens ──────────────────────────────────────────────────────────────
+
+func (s *Store) CreateAgentToken(t *common.AgentToken) error {
+	_, err := s.db.Exec(
+		`INSERT INTO agent_tokens (id, agent_id, token_hash, created_at, expires_at, revoked_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		t.ID, t.AgentID, t.TokenHash,
+		encodeTime(t.CreatedAt),
+		encodeTimePtr(t.ExpiresAt),
+		encodeTimePtr(t.RevokedAt),
+	)
+	return err
+}
+
+func (s *Store) GetAgentTokenByHash(hash string) (*common.AgentToken, error) {
+	row := s.db.QueryRow(
+		`SELECT id, agent_id, token_hash, created_at, expires_at, revoked_at
+		 FROM agent_tokens WHERE token_hash = ?`, hash)
+	var t common.AgentToken
+	var createdAt string
+	var expiresAt, revokedAt sql.NullString
+	if err := row.Scan(&t.ID, &t.AgentID, &t.TokenHash, &createdAt, &expiresAt, &revokedAt); err != nil {
+		return nil, err
+	}
+	t.CreatedAt = decodeTime(createdAt)
+	t.ExpiresAt = decodeTimePtr(expiresAt)
+	t.RevokedAt = decodeTimePtr(revokedAt)
+	return &t, nil
+}
+
+func (s *Store) RevokeAgentToken(id string) error {
+	_, err := s.db.Exec(
+		`UPDATE agent_tokens SET revoked_at = ? WHERE id = ?`,
+		encodeTime(time.Now()), id)
+	return err
+}
+
+func (s *Store) RevokeAllAgentTokens(agentID string) error {
+	_, err := s.db.Exec(
+		`UPDATE agent_tokens SET revoked_at = ? WHERE agent_id = ? AND revoked_at IS NULL`,
+		encodeTime(time.Now()), agentID)
+	return err
+}


### PR DESCRIPTION
This pull request introduces a major redesign of agent authentication, replacing JWTs with opaque, centrally managed tokens. The changes enhance security, enable instant token revocation and rotation, and clarify the distinction between agent and UI authentication. The update also improves documentation and status naming consistency.

**Agent Authentication Redesign**

* Agents now authenticate using opaque, randomly generated bearer tokens (`kpkt_<hex>`) instead of JWTs. Only a SHA-256 hash is stored in the database, allowing instant revocation and zero-downtime rotation. [[1]](diffhunk://#diff-d477692fe261adf1085cbddea2296261a3f28cce7cdebf04399b60ded654def2L19-R90) [[2]](diffhunk://#diff-0ba875d20f5a97f8671b587d1888ae88a5dc2575d3dacf69522d385838752de0R1-R102) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48)
* All agent token logic (issuance, validation, revocation, rotation) is implemented in `internal/server/handlers/auth.go` and documented in `docs/agent-authentication.md`. [[1]](diffhunk://#diff-d477692fe261adf1085cbddea2296261a3f28cce7cdebf04399b60ded654def2L19-R90) [[2]](diffhunk://#diff-0ba875d20f5a97f8671b587d1888ae88a5dc2575d3dacf69522d385838752de0R1-R102)
* On agent re-registration, all previous tokens for that agent are revoked before issuing a new one, preventing stale credentials. [[1]](diffhunk://#diff-d477692fe261adf1085cbddea2296261a3f28cce7cdebf04399b60ded654def2L264-R290) [[2]](diffhunk://#diff-d477692fe261adf1085cbddea2296261a3f28cce7cdebf04399b60ded654def2R253) [[3]](diffhunk://#diff-d477692fe261adf1085cbddea2296261a3f28cce7cdebf04399b60ded654def2L195-R219)

**UI Authentication Separation**

* UI sessions continue to use short-lived JWTs, with the authentication logic separated from agent tokens. Documentation and code clarify this distinction. [[1]](diffhunk://#diff-d477692fe261adf1085cbddea2296261a3f28cce7cdebf04399b60ded654def2R111-L108) [[2]](diffhunk://#diff-0ba875d20f5a97f8671b587d1888ae88a5dc2575d3dacf69522d385838752de0R1-R102) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48)

**Configuration and Code Cleanup**

* Removed the unused `AgentJWTSecret` field from `ServerConfig` and related code, since agent tokens are now opaque and not signed. [[1]](diffhunk://#diff-ae81a054e174c097fd320dcc5ddb4f7bde956a1c26392c5dc4eec3c992f8dbd9L59-R59) [[2]](diffhunk://#diff-ae81a054e174c097fd320dcc5ddb4f7bde956a1c26392c5dc4eec3c992f8dbd9L103) [[3]](diffhunk://#diff-daf3824d8525da7bb3ee1fef200c959c0a7fd7e7f64460fe9e3e9946cfabe672L34-R34)
* Added the `AgentToken` struct to `internal/common/types.go` for token management.

**Documentation and Status Naming Consistency**

* Added a new documentation file `docs/agent-authentication.md` and updated `README.md` to reference it and clarify troubleshooting steps for agent token errors. [[1]](diffhunk://#diff-0ba875d20f5a97f8671b587d1888ae88a5dc2575d3dacf69522d385838752de0R1-R102) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R115)
* Standardized status names from `done` to `completed` for agents and deployments in `internal/common/types.go`. [[1]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL155-R155) [[2]](diffhunk://#diff-0adb3f074b72922964e61d832f1a6c16290bc9cc91f421912571543625ea1eaaL186-R186)