### PR TITLE
Run playbook execution in a separate goroutine for improved concurrency

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -199,7 +199,7 @@ func (c *Agent) connect(ctx context.Context) error {
 				slog.Warn("invalid playbook message", "error", err)
 				continue
 			}
-			c.runPlaybook(ctx, writer, &pd)
+			go c.runPlaybook(ctx, writer, &pd)
 
 		case common.WSMsgCommand:
 			raw, _ := json.Marshal(msg.Data)


### PR DESCRIPTION
This pull request makes a targeted change to how playbooks are executed in the `Agent` component. The main improvement is that playbooks are now run asynchronously, allowing the agent to handle multiple playbook executions concurrently and improving overall responsiveness.

Concurrency improvement:

* Updated `connect` method in `agent.go` to run `runPlaybook` in a separate goroutine, enabling concurrent playbook execution and preventing blocking of the main message handling loop.